### PR TITLE
Remove ccsp-safenat-broadband recipe override

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-safenat-broadband.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-safenat-broadband.bbappend
@@ -1,1 +1,0 @@
-require ccsp_common_turris.inc


### PR DESCRIPTION
The CcspSafeNAT component has been deprecated.