### PR TITLE
Fix extsrc build for ccsp-gwprovapp-ethwan

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-gwprovapp-ethwan.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-gwprovapp-ethwan.bbappend
@@ -7,7 +7,7 @@ export PLATFORM_TURRIS_ENABLED="yes"
 inherit systemd
 
 do_compile_append () { 
-	cp ${WORKDIR}/build/source/gw_prov_ethwan	${S}/source
+	cp ${B}/source/gw_prov_ethwan	${S}/source
 }
 
 do_install_append () {


### PR DESCRIPTION
The B variable should be used for build objects so that
extsrc builds can locate them.