### PR TITLE
Add extsrc support for ccsp-gwprovapp

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-gwprovapp.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-gwprovapp.bbappend
@@ -2,8 +2,19 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 require ccsp_common_turris.inc
 
-SRC_URI += " file://turris-macro-gwprov.patch"
-SRC_URI += " file://set-uplink-for-turris.patch"
+SRC_URI += " file://turris-macro-gwprov.patch;apply=no"
+SRC_URI += " file://set-uplink-for-turris.patch;apply=no"
+
+# we need to patch to code for Turris
+do_rpi_patches() {
+    cd ${S}
+    if [ ! -e patch_applied ]; then
+        patch -p1 < ${WORKDIR}/turris-macro-gwprov.patch
+        patch -p1 < ${WORKDIR}/set-uplink-for-turris.patch
+        touch patch_applied
+    fi
+}
+addtask rpi_patches after do_unpack before do_compile
 
 DEPENDS_remove = " ruli"
 


### PR DESCRIPTION
SRC_URI patching is not compatible with EXTSRC support, so
modifying the patching to be done via a new function between
unpack and compile to make sure the patches are always
applied.