### PR TITLE
Remove quagga recipe override

### DIFF
--- a/recipes-protocols/quagga/quagga_%.bbappend
+++ b/recipes-protocols/quagga/quagga_%.bbappend
@@ -1,3 +1,0 @@
-do_install_append() {
- sed -i "s/PIDFile/#&/" ${D}/lib/systemd/system/zebra.service
-}


### PR DESCRIPTION
This causes build failures after Gerrit change 31114 is merged, where
the zebra.service has been removed.