### PR TITLE
Add extsrc support for ccsp-lm-lite

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-lm-lite.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-lm-lite.bbappend
@@ -3,4 +3,14 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 LDFLAGS_append = " -Wl,--no-as-needed"
 
-SRC_URI += "file://musl-header-missing.patch"
+SRC_URI += "file://musl-header-missing.patch;apply=no"
+
+# we need to patch to code for Turris
+do_rpi_patches() {
+    cd ${S}
+    if [ ! -e patch_applied ]; then
+        patch -p1 < ${WORKDIR}/musl-header-missing.patch
+        touch patch_applied
+    fi
+}
+addtask rpi_patches after do_unpack before do_compile


### PR DESCRIPTION
SRC_URI patching is not compatible with EXTSRC support, so
modifying the patching to be done via a new function between
unpack and compile to make sure the patches are always
applied.