### PR TITLE
Disable alljoyn

### DIFF
--- a/recipes-core/packagegroups/packagegroup-rdk-oss-broadband.bbappend
+++ b/recipes-core/packagegroups/packagegroup-rdk-oss-broadband.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_packagegroup-rdk-oss-broadband_remove = "alljoyn"


### PR DESCRIPTION
alljoyn has been fixed for morty after 31223 is merged.
But it does not build for Turris Omnia.
Disabling for Turris here.