### PR TITLE
Update git variables to use those from meta-cmf

### DIFF
--- a/conf/machine/turris.conf
+++ b/conf/machine/turris.conf
@@ -27,7 +27,3 @@ PREFERRED_VERSION_php-native = "7.1.%"
 
 #require conf/include/rdk-bbmasks-broadband.inc
 KERNEL_IMAGETYPE = "zImage"
-
-RDKCENTRAL_GITHUB_BRANCH ?= "master"
-RDKCENTRAL_GITHUB_ROOT ?= "git://github.com/rdkcentral"
-RDKCENTRAL_GITHUB_PROTOCOL ?= "https"

--- a/recipes-ccsp/hal/hal-dhcpv4c-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-dhcpv4c-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${RDKCENTRAL_GITHUB_ROOT}/rdkb-turris-hal;protocol=${RDKCENTRAL_GITHUB_PROTOCOL};branch=${RDKCENTRAL_GITHUB_BRANCH};destsuffix=git/source/dhcpv4c/devices;name=dhcphal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkcentral/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};destsuffix=git/source/dhcpv4c/devices;name=dhcphal-turris"
 
 SRCREV_dhcphal-turris = "${AUTOREV}"
 

--- a/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${RDKCENTRAL_GITHUB_ROOT}/rdkb-turris-hal;protocol=${RDKCENTRAL_GITHUB_PROTOCOL};branch=${RDKCENTRAL_GITHUB_BRANCH};destsuffix=git/source/ethsw/devices;name=ethswhal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkcentral/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};destsuffix=git/source/ethsw/devices;name=ethswhal-turris"
 
 SRCREV_ethswhal-turris = "${AUTOREV}"
 

--- a/recipes-ccsp/hal/hal-platform-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-platform-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${RDKCENTRAL_GITHUB_ROOT}/rdkb-turris-hal;protocol=${RDKCENTRAL_GITHUB_PROTOCOL};branch=${RDKCENTRAL_GITHUB_BRANCH};destsuffix=git/source/platform/devices;name=platformhal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkcentral/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};destsuffix=git/source/platform/devices;name=platformhal-turris"
 
 SRCREV = "${AUTOREV}"
 

--- a/recipes-ccsp/hal/hal-wifi-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-wifi-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${RDKCENTRAL_GITHUB_ROOT}/rdkb-turris-hal;protocol=${RDKCENTRAL_GITHUB_PROTOCOL};branch=${RDKCENTRAL_GITHUB_BRANCH};destsuffix=git/source/wifi/devices;name=wifihal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkcentral/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};destsuffix=git/source/wifi/devices;name=wifihal-turris"
 
 SRCREV = "${AUTOREV}"
 


### PR DESCRIPTION
The git variables in meta-cmf are used to control
branching and releases and should be used instead.