### PR TITLE
Disable safec

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "turris"
 BBFILE_PATTERN_turris = "^${LAYERDIR}/"
 BBFILE_PRIORITY_turris = "8"
+
+DISTRO_FEATURES_remove = "safec"


### PR DESCRIPTION
RDK Central Gerrit change meta-rdk 33063 enabled safec as default for all
RDK-B and RDK-V builds. But Turris build does not support safec, disabling it.