### PR TITLE
REFPLTB-486 safec does not compile for Turris Omnia

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,5 +8,3 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "turris"
 BBFILE_PATTERN_turris = "^${LAYERDIR}/"
 BBFILE_PRIORITY_turris = "8"
-
-DISTRO_FEATURES_remove = "safec"

--- a/recipes-core/safec/safec_3.5.bbappend
+++ b/recipes-core/safec/safec_3.5.bbappend
@@ -1,0 +1,3 @@
+SRC_URI_remove = "file://0001-memrchr-Use-_ISOC11_SOURCE-only-with-glibc.patch"
+
+CPPFLAGS_remove = "-D_GNU_SOURCE"


### PR DESCRIPTION
Adding safec overrides to fix compilation errors for safec in Turris Omnia.