### PR TITLE
REFPLTB-521 Enable IPv6 support on Turris Omnia

### DIFF
--- a/recipes-ccsp/util/utopia/system_defaults
+++ b/recipes-ccsp/util/utopia/system_defaults
@@ -109,7 +109,7 @@ $$Version=11
 # 1 - IPv4
 # 2 - IPv6
 # 3 - IPv4 and IPv6
-$last_erouter_mode=1
+$last_erouter_mode=3
 
 # wan_physical_ifname - the name (as known to the OS) of the physical interface
 #    that is used for the wan. This setting is not meant for users to manipulate.
@@ -937,3 +937,5 @@ $wan_default_gateway=0.0.0.0
 $nameserver1=0.0.0.0
 $nameserver2=0.0.0.0
 $hostname=TurrisOmnia-GW
+
+$IPv6subPrefix=true

--- a/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -1,3 +1,4 @@
 do_install_append() {
     echo "BOX_TYPE=turris" >> ${D}${sysconfdir}/device.properties
+    echo "ARM_INTERFACE=erouter0" >> ${D}${sysconfdir}/device.properties
 }


### PR DESCRIPTION
Reason for change: Enable IPv6 support on Turris Omnia. 
Test Procedure:
        * Verify that both ”Dibbler-client” and “dibbler-server” are running
	* Verify that the interfaces “erouter0” and “brlan0” on Turris Omnia have the IPv6 addresses.
	* Connect a client PC to the Turris Omnia by lan and verify that it has IPv6 address