### PR TITLE
REFPLTB-559 Switch from musl to glibc for broadband profile

### DIFF
--- a/conf/machine/turris.conf
+++ b/conf/machine/turris.conf
@@ -15,7 +15,7 @@ MACHINE_EXTRA_RRECOMMENDS += "kernel-modules"
 IMAGE_BOOT_FILES = "zImage zImage-armada-385-turris-omnia.dtb;armada-385-turris-omnia.dtb boot.scr"
 
 MACHINE_IMAGE_NAME = "rdkb-generic-broadband-image"
-TCLIBC = "musl"
+TCLIBC = "glibc"
 
 MACHINEOVERRIDES .= ":broadband:turris"
 

--- a/recipes-core/systemd/systemd_230.bbappend
+++ b/recipes-core/systemd/systemd_230.bbappend
@@ -1,4 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI += "file://systemd-turris.patch"
-SRC_URI += "file://systemd-set-wdt.patch"
-SRC_URI += "file://systemd-strerror_r-handling.patch"
+SRC_URI_append_extender = " \
+    file://systemd-turris.patch \
+"
+SRC_URI_append = " \
+    file://systemd-set-wdt.patch \
+    file://systemd-strerror_r-handling.patch \
+    "


### PR DESCRIPTION
glibc is needed to build rbus and rbus-core.
extender profile remains with musl