### PR TITLE
REFPLTB-550: Bringing WebPA support for Turris Omnia

### DIFF
--- a/recipes-support/parodus/files/parodus.service
+++ b/recipes-support/parodus/files/parodus.service
@@ -1,0 +1,29 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2018 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+[Unit]
+Description=Parodus
+After=PsmSsp.service CcspPandMSsp.service ccspwifiagent.service CcspLMLite.service
+
+[Service]
+ExecStart=/bin/sh -c '/lib/rdk/parodus_start.sh;'
+Type=forking
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-support/parodus/files/parodus_start.sh
+++ b/recipes-support/parodus/files/parodus_start.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2018 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+BINPATH="/usr/bin"
+GET="dmcli eRT getv"
+SET=""
+
+echo "Check parodusCmd.cmd in /tmp"
+
+if [ -e /tmp/parodusCmd.cmd ]; then
+ parodusCmd=`cat /tmp/parodusCmd.cmd`
+ $parodusCmd &
+else
+ echo "parodusCmd.cmd does not exist in tmp"
+ echo "Fetching PAM Health status "
+
+  while [ 1 ]
+  do
+     pamState=`$GET com.cisco.spvtg.ccsp.pam.Health | grep value| tr -s ' ' |cut -f5 -d" "`
+     if [ "$pamState" = "Green" ]; then
+          break
+     else
+        echo "Waiting for PAM to come up"
+     fi
+     sleep 10
+  done
+
+  echo "Fetching CMAgent Health status "
+
+
+  echo "Fetching values to form parodus command line arguments"
+
+  ModelName=`$GET Device.DeviceInfo.ModelName | grep value| tr -s ' ' |cut -f5 -d" "`
+  SerialNumber=`$GET Device.DeviceInfo.SerialNumber | grep value| tr -s ' ' |cut -f5 -d" "`
+  Manufacturer=`$GET Device.DeviceInfo.Manufacturer | grep value| tr -s ' ' |cut -f5 -d" "`
+  HW_MAC=`$GET Device.X_CISCO_COM_CableModem.MACAddress | grep value| tr -s ' ' |cut -f5 -d" "`
+  HW_MAC=`ifconfig erouter0 | grep HWaddr | tr -s ' ' | cut -d ' ' -f5`
+  LastRebootReason=`$GET Device.DeviceInfo.X_RDKCENTRAL-COM_LastRebootReason | grep value| tr -s ' ' |cut -f5 -d" "`
+  FirmwareName=`$GET Device.DeviceInfo.X_CISCO_COM_FirmwareName | grep value| tr -s ' ' |cut -f5 -d" "`
+  BootTime=`$GET Device.DeviceInfo.X_RDKCENTRAL-COM_BootTime | grep value| tr -s ' ' |cut -f5 -d" "`
+  MaxPingWaitTimeInSec=180;
+  DeviceNetworkInterface="erouter0";
+  ServerURL=http://54.166.121.187:8080;
+  BackOffMax=9;
+  PARODUS_URL=tcp://127.0.0.1:6666;
+  SSL_CERT_PATH=/etc/ssl/certs/ca-certificates.crt
+
+  echo "Framing command for parodus"
+
+#  command="/usr/bin/parodus --hw-model=$ModelName --hw-serial-number=$SerialNumber --hw-manufacturer=$Manufacturer --hw-mac=$HW_MAC --hw-last-reboot-reason=$LastRebootReason --fw-name=$FirmwareName --boot-time=$BootTime --webpa-ping-time=$MaxPingWaitTimeInSec --webpa-inteface-used=$DeviceNetworkInterface --webpa-url=$ServerURL --webpa-backoff-max=$BackOffMax"
+   command="/usr/bin/parodus --hw-model=$ModelName --hw-serial-number=$SerialNumber --hw-manufacturer=$Manufacturer --hw-last-reboot-reason=$LastRebootReason --fw-name=$FirmwareName --boot-time=$BootTime --hw-mac=$HW_MAC --webpa-ping-time=180 --webpa-interface-used=erouter0 --webpa-url=$ServerURL --webpa-backoff-max=$BackOffMax  --parodus-local-url=$PARODUS_URL --partner-id=comcast --ssl-cert-path=$SSL_CERT_PATH --force-ipv4 " 
+
+  echo $command >/tmp/parodusCmd.cmd
+
+  echo "Starting parodus with the following arguments"
+  echo "ModelName=$ModelName  SerialNumber=$SerialNumber  Manufacturer=$Manufacturer  HW_MAC=$HW_MAC  LastRebootReason=$LastRebootReason  FirmwareName=$FirmwareName  BootTime=$BootTime  MaxPingWaitTimeInSec=$MaxPingWaitTimeInSec   DeviceNetworkInterface=$DeviceNetworkInterface  ServerURL=$ServerURL BackOffMax=$BackOffMax"
+
+  $command &
+fi

--- a/recipes-support/parodus/parodus_1.0.bbappend
+++ b/recipes-support/parodus/parodus_1.0.bbappend
@@ -5,3 +5,25 @@ CFLAGS_remove = "-I${STAGING_INCDIR}/ucresolv"
 CFLAGS_remove = "-DFEATURE_DNS_QUERY"
 
 EXTRA_OECMAKE_remove = "-DFEATURE_DNS_QUERY=true"
+
+inherit systemd coverity
+
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://parodus.service"
+SRC_URI += "file://parodus_start.sh"
+
+do_install_append_broadband () {
+    install -d ${D}${systemd_unitdir}/system
+    install -d ${D}${base_libdir_native}/rdk
+    install -m 0644 ${WORKDIR}/parodus.service ${D}${systemd_unitdir}/system
+    install -m 0755 ${WORKDIR}/parodus_start.sh ${D}${base_libdir_native}/rdk
+}
+
+SYSTEMD_SERVICE_${PN}_append_broadband = " parodus.service"
+
+FILES_${PN}_append_broadband = " \
+     ${systemd_unitdir}/system/parodus.service \
+     ${base_libdir_native}/rdk/* \
+"


### PR DESCRIPTION
Reason for change: Incorporating WebPA component for Remote Management functionality
Test Procedure: The parodus service should be active. Through curl commands the connection
with WebPA Server will be established by the get/set data parameters
Risks: low

Signed-off-by: rajakumaran.a <rajakumaran.a@lnttechservices.com>