### PR TITLE
Add rdk-logger dependency to opensync

### DIFF
--- a/recipes-connectivity/opensync/opensync_1.4.0.bbappend
+++ b/recipes-connectivity/opensync/opensync_1.4.0.bbappend
@@ -11,6 +11,7 @@ PLATFORM_URI += "file://MeshAgentSync.patch;patchdir=${WORKDIR}/git/platform/rdk
 VENDOR_URI = "git://git@github.com/rdkcentral/opensync-vendor-rdk-turris.git;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};name=vendor;destsuffix=git/vendor/turris"
 
 DEPENDS_remove = "${@bb.utils.contains('DISTRO_FEATURES', 'extender', 'mesh-agent', '', d)}"
+DEPENDS_append = " rdk-logger"
 
 RDK_CFLAGS += " -D_PLATFORM_TURRIS_"
 


### PR DESCRIPTION
This should fix the build error:
| platform/rdk/src/pl2rld/pl2rld.c:46:23: fatal error: rdk_debug.h: No such file or directory
|  #include <rdk_debug.h>
|                        ^
| compilation terminated.
| make: *** [work/RDKB/obj/platform.rdk.src.pl2rld/platform/rdk/src/pl2rld/pl2rld.o] Error 1