### PR TITLE
Add turris-bci to support ccsp-webui-bci build

### DIFF
--- a/conf/machine/turris-bci.conf
+++ b/conf/machine/turris-bci.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: turris-bci
+#@NEEDED_BSPLAYERS: meta-turris
+#@DESCRIPTION: Machine configuration for running a RDK broadband on turris omnia
+#@RDK_FLAVOR: rdkb
+
+MACHINEOVERRIDES .= ":bci"
+
+require turris.conf
+
+DISTRO_FEATURES_append = " bci"

--- a/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -9,7 +9,7 @@ SYSTEMD_TOOLS_remove_libc-musl = "systemd-bootchart"
 IMAGE_INSTALL += " packagegroup-turris-core \
     ${SYSTEMD_TOOLS} \
     linux-firmware-ath10k \
-    ccsp-webui \
+    ccsp-webui-csrf \
     network-hotplug \
     php \
     libmcrypt \


### PR DESCRIPTION
A new machine config is needed to enable the bci DISTRO_FEATURES for
ccsp-webui-bci instead of ccsp-webui.