### PR TITLE
RDKB-26019:Instrument hostapd component to use Telemetry 2.0

### DIFF
--- a/recipes-connectivity/hostapd/hostapd_2.9.bb
+++ b/recipes-connectivity/hostapd/hostapd_2.9.bb
@@ -5,6 +5,8 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://hostapd/README;md5=1ec986bec88070e2a59c68c95d763f89"
 
 DEPENDS = "libnl openssl"
+DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'telemetry2_0', 'telemetry', '', d)}"
+LDFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'telemetry2_0', ' -ltelemetry_msgsender ', '', d)}"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI = " \


### PR DESCRIPTION
Reason for change: Instrument hostapd component to use Telemetry 2.0
Test Procedure: Telemetry markers For hostapd should come in Splunk (Please Refer Telemetry testing procedure in https://etwiki.sys.comcast.net/pages/viewpage.action?spaceKey=CPE&title=RDK-B+Steps+to+enable+Telemetry+2.0)
Risks: Low

Signed-off-by:DurgaPrasad_Aripaka@comcast.com
(cherry picked from commit 81d5d57ea07df947e8087f37bf1ee3759e59122b)