### PR TITLE
Startup fix

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-common-library/checkturriswifisupport.service
+++ b/recipes-ccsp/ccsp/ccsp-common-library/checkturriswifisupport.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Check WIFI support on Turris Omnia device
+After=hostapd.service
 
 [Service]
 Type=forking

--- a/recipes-common/mesh-agent/mesh-agent.bbappend
+++ b/recipes-common/mesh-agent/mesh-agent.bbappend
@@ -8,6 +8,12 @@ do_configure_prepend()  {
 patch  -p3 --forward < ${WORKDIR}/dns.patch ${S}/source/MeshAgentSsp/cosa_mesh_apis.c  || echo "patch already applied"
 }
 
+do_install_append () {
+	install -D -m 0644 ${S}/systemd_units/meshAgent.service ${D}${systemd_unitdir}/system/meshAgent.service
+}
+
+FILES_${PN}_append = "${systemd_unitdir}/system/meshAgent.service"
+
 CFLAGS_append = " -D_PLATFORM_TURRIS_"
 
 

--- a/recipes-connectivity/hostapd/files/hostapd-init.sh
+++ b/recipes-connectivity/hostapd/files/hostapd-init.sh
@@ -91,6 +91,14 @@ touch /tmp/hostapd-acl3
 touch /tmp/hostapd-acl4
 touch /tmp/hostapd-acl5
 
+#create empty psk files
+touch /tmp/hostapd0.psk
+touch /tmp/hostapd1.psk
+touch /tmp/hostapd2.psk
+touch /tmp/hostapd3.psk
+touch /tmp/hostapd4.psk
+touch /tmp/hostapd5.psk
+
 #Setting brlan0 bridge
 if [ ! -f /sys/class/net/brlan0 ]
 then

--- a/recipes-networking/openvswitch/openvswitch_git.bbappend
+++ b/recipes-networking/openvswitch/openvswitch_git.bbappend
@@ -1,0 +1,2 @@
+#disable openvswitch autostart
+SYSTEMD_SERVICE_${PN}-switch = ""


### PR DESCRIPTION
Fixed startup
- do not start openvswitch on boot
- fix ccspwifiagent startup
- add meshAgent systemd service

Additional fixes
added empty psk files for all VAPs needed for multi-psk support.