### PR TITLE
BLDK-734:RDK License header changes-for Notice header update

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,12 @@
-Copyright 2019 RDK Management
-Licensed under the MIT License
+This component contains software that is Copyright (c) 2019 RDK Management.
+The component is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use the component except in compliance with the License.
 
-Copyright 2019 RDK Management
-Licensed under the Apache-2.0 License
+The component may include material which is licensed under other licenses / copyrights as
+listed below. Your use of this material within the component is also subject to the terms and
+conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
+within this component.
+
+
 
 Some material is derived from https://github.com/openembedded and was licensed under an MIT license.


### PR DESCRIPTION
BLDK-734:RDK License header changes-for Notice header update
Reason for change: RDK License header changes-for Notice header update
Test Procedure: Jenkin build should pass after License header changes for RDK for listed repos
Risks: None