### PR TITLE
Setting ccsp-arch=arm to include other source files in Test & Diagnostic

### DIFF
--- a/recipes-ccsp/util/test-and-diagnostic.bbappend
+++ b/recipes-ccsp/util/test-and-diagnostic.bbappend
@@ -4,3 +4,5 @@ do_install_append () {
     # Test and Diagonastics XML 
        install -m 644 ${S}/config/TestAndDiagnostic_arm.XML ${D}/usr/ccsp/tad/TestAndDiagnostic.XML
 }
+
+EXTRA_OECONF_append  = " --with-ccsp-arch=arm"


### PR DESCRIPTION
Signed-off-by: Manigandan Gopalakrishnan <manigandan.gopalakrishnan@ltts.com>