### PR TITLE
RDKB-29287: Convert Broadband default SRC_URIs to use RDKCentral

### DIFF
--- a/recipes-ccsp/ccsp/ccsp_common_turris.inc
+++ b/recipes-ccsp/ccsp/ccsp_common_turris.inc
@@ -6,3 +6,6 @@ CFLAGS_append += " -U_COSA_SIM_ -fno-exceptions -ffunction-sections -fdata-secti
            -D_ANSC_AES_USED_ -D_NO_EXECINFO_H_ -DFEATURE_SUPPORT_SYSLOG \
            -DBUILD_WEB -D_NO_ANSC_ZLIB_ -D_DEBUG -U_ANSC_IPV6_COMPATIBLE_ -DUSE_NOTIFY_COMPONENT \
            -D_PLATFORM_TURRIS_ -DENABLE_SD_NOTIFY -DCOSA_DML_WIFI_FEATURE_LoadPsmDefaults -UPARODUS_ENABLE -DENABLE_FEATURE_MESHWIFI"
+
+DEPENDS += "breakpad-wrapper"
+LDFLAGS += "-lbreakpadwrapper"

--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -1,6 +1,6 @@
 require recipes-ccsp/ccsp/ccsp_common_turris.inc
 
-DEPENDS_append = " kernel-autoconf utopia-headers"
+DEPENDS_append = " kernel-autoconf utopia-headers libsyswrapper"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
@@ -16,6 +16,10 @@ SRC_URI += "file://posix-gwprovapp.patch;apply=no"
 #This patch will add dummy swctl api which is originally given by brcm for XB3.
 SRC_URI += "file://0002-fix-swctl-missing-api.patch;apply=no"
 SRC_URI += "file://dhcp_script.sh"
+
+LDFLAGS_append = " \
+    -lsecure_wrapper \
+"
 
 # we need to patch to code for Turris
 do_turris_patches() {


### PR DESCRIPTION
Reason for change: Make SRC_URI changes for broaband layer recipes to use rdkcentral repo for
default instead of Comcast
Test Procedure: Verify that RDKB builds works fine.
Risks: Low