### PR TITLE
Remove bbmask for ccsp-webui-bci

### DIFF
--- a/conf/include/turris-bbmasks-broadband.inc
+++ b/conf/include/turris-bbmasks-broadband.inc
@@ -1,2 +1,1 @@
-BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-webui-bci.bb"
 BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-hotspot-kmod.bb"


### PR DESCRIPTION
It is needed for Turris BB BCI builds.