### PR TITLE
Switch hal to use CMF_GITHUB_MASTER_BRANCH for git branching

### DIFF
--- a/recipes-ccsp/hal/hal-dhcpv4c-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-dhcpv4c-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};destsuffix=git/source/dhcpv4c/devices;name=dhcphal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/dhcpv4c/devices;name=dhcphal-turris"
 
 SRCREV_dhcphal-turris = "${AUTOREV}"
 

--- a/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};destsuffix=git/source/ethsw/devices;name=ethswhal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/ethsw/devices;name=ethswhal-turris"
 
 SRCREV_ethswhal-turris = "${AUTOREV}"
 

--- a/recipes-ccsp/hal/hal-platform-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-platform-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};destsuffix=git/source/platform/devices;name=platformhal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/platform/devices;name=platformhal-turris"
 
 SRCREV = "${AUTOREV}"
 

--- a/recipes-ccsp/hal/hal-wifi-turris_git.bb
+++ b/recipes-ccsp/hal/hal-wifi-turris_git.bb
@@ -9,7 +9,7 @@ inherit autotools coverity
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI = "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_MASTER_BRANCH};name=wifihal"
+SRC_URI = "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};name=wifihal"
 SRCREV_wifihal = "${AUTOREV}"
 SRCREV_FORMAT = "wifihal"
 


### PR DESCRIPTION
It is needed because Github components need separate variable for
the CMF branch as they do not have rdk-dev branches.