### PR TITLE
Revert "Adding 'gtest' build dependency for msgpack-c"

### DIFF
--- a/recipes-support/msgpack/msgpack-c_%.bbappend
+++ b/recipes-support/msgpack/msgpack-c_%.bbappend
@@ -1,1 +1,0 @@
-DEPENDS += "gtest"


### PR DESCRIPTION
This reverts commit 67b05fe61ed1063dd24e0226d7201a13389eb848.