### PR TITLE
Fix turris extender dunfell build

### DIFF
--- a/conf/include/turris-bbmasks-extender.inc
+++ b/conf/include/turris-bbmasks-extender.inc
@@ -3,6 +3,7 @@ BBMASK .= "|meta-rdk-broadband/recipes-ccsp/ccsp/ccsp-webui-jst.bb"
 
 BBMASK .= "|meta-rdk/recipes-core/packagegroups/packagegroup-rdk-media-common.bb"
 
+BBMASK .= "|meta-rdk-ext/recipes-common/rtmessage/"
 BBMASK .= "|meta-rdk-ext/recipes-support/base64/base64_git.bb"
 BBMASK .= "|meta-rdk-ext/recipes-kernel/linux/linux-libc-headers_%.bbappend"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,6 +9,8 @@ BBFILE_COLLECTIONS += "turris"
 BBFILE_PATTERN_turris = "^${LAYERDIR}/"
 BBFILE_PRIORITY_turris = "8"
 
+LAYERSERIES_COMPAT_turris = "dunfell"
+
 DISTRO_FEATURES_remove_dunfell = "telemetry2_0"
 
 DISTRO_FEATURES_remove = "webui_jst"

--- a/conf/machine/turris-extender.conf
+++ b/conf/machine/turris-extender.conf
@@ -4,7 +4,7 @@
 #@DESCRIPTION: Machine configuration for running a RDK Extender on turris omnia
 #@RDK_FLAVOR: rdkb
 
-require conf/machine/include/armada38x-base.inc
+require conf/machine/include/armada38x-base-turris.inc
 
 KERNEL_DEVICETREE = "armada-385-turris-omnia.dtb"
 
@@ -44,3 +44,6 @@ RDKCENTRAL_GITHUB_PROTOCOL ?= "https"
 
 DISTRO_FEATURES_append = " extender"
 DISTRO_FEATURES_remove = "telemetry2_0"
+
+#masking files for dunfell build
+require conf/include/turris-bbmasks-extender.inc

--- a/recipes-support/dnsmasq/dnsmasq_%.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_%.bbappend
@@ -1,4 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://dnsmasq.conf"
-SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'extender', 'file://300-vendor-class-dhcp-lease-file.patch', '', d)}"

--- a/recipes-support/dnsmasq/dnsmasq_2.78.bbappend
+++ b/recipes-support/dnsmasq/dnsmasq_2.78.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'extender', 'file://300-vendor-class-dhcp-lease-file.patch', '', d)}"


### PR DESCRIPTION
Fixes include:
Enable BBMASK for extender
dunfell LAYERSERIES_COMPAT
Extender machine inherits from armada38x-base-turris.inc
Update dnsmasq patch