### PR TITLE
Temporary workaround for ccsp-p-and-m build errors

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
@@ -34,6 +34,8 @@ LDFLAGS_remove = " \
     -lmoca_mgnt \
 "
 
+CFLAGS_remove = "-Werror"
+
 EXTRA_OECONF_append  = " --with-ccsp-arch=arm"
 
 do_install_append(){


### PR DESCRIPTION
Build is failing when all warnings are treated as errors
in meta-rdk-broadband/52102

Temporary removing -Werror until the source code in CcspPandM
is fixed.