### PR TITLE
Adding initial recipe for multiap-Controller

### DIFF
--- a/recipes-connectivity/multiapcontroller/multiapcontroller_git.bb
+++ b/recipes-connectivity/multiapcontroller/multiapcontroller_git.bb
@@ -1,17 +1,14 @@
-UMMARY = "OpenSource Multiapcontroller implementation"
+SUMMARY = "OpenSource Multiapcontroller implementation"
+
 LICENSE = "BSD-2-Clause-Patent"
+
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d5d0e19d5fa4af3f7d9817fb77a9bfb1"
 
 DEPENDS = "openssl libpcap"
+
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/TechnicolorEDGM/multiap_controller.git"
-
-
-
-
-SRC_URI[md5sum] = "${AUTOREV}"
-SRC_URI[sha256sum] = "${AUTOREV}"
 
 SRCREV = "${AUTOREV}"
 

--- a/recipes-connectivity/multiapcontroller/multiapcontroller_git.bb
+++ b/recipes-connectivity/multiapcontroller/multiapcontroller_git.bb
@@ -1,0 +1,40 @@
+UMMARY = "OpenSource Multiapcontroller implementation"
+LICENSE = "BSD-2-Clause-Patent"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d5d0e19d5fa4af3f7d9817fb77a9bfb1"
+
+DEPENDS = "openssl libpcap"
+S = "${WORKDIR}/git"
+
+SRC_URI = "git://github.com/TechnicolorEDGM/multiap_controller.git"
+
+
+
+
+SRC_URI[md5sum] = "${AUTOREV}"
+SRC_URI[sha256sum] = "${AUTOREV}"
+
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+CFLAGS_append = " \
+                "
+
+LDFLAGS_append = " \
+    -lpthread \
+    -lpcap \
+    -lcrypto \
+    -lrt \
+    "
+
+#force lib to be built first
+do_compile () {
+    PLATFORM=linux FLAVOUR=RDK make
+}
+
+do_install () {
+    # Config files and scripts
+    install -d ${D}/usr/bin
+    
+}
+


### PR DESCRIPTION
REFPLTB-898: Adding initial recipe for multiap-Controller
Reason for change: Needed for integrating TCH easymesh impl
Test Procedure: TBD

Risks: None
Signed-off-by: vijayapadma.t <vijayapadma.t@ltts.com>