### PR TITLE
Add telemetry dependency to utopia

### DIFF
--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -1,6 +1,6 @@
 require recipes-ccsp/ccsp/ccsp_common_turris.inc
 
-DEPENDS_append = " kernel-autoconf utopia-headers libsyswrapper"
+DEPENDS_append = " kernel-autoconf utopia-headers libsyswrapper telemetry"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 


### PR DESCRIPTION
It is needed after Utopia/53954 is merged.