### PR TITLE
REFPLTB-1032 : Recent morty and dunfell builds are breaking due to RD…

### DIFF
--- a/recipes-common/rtmessage/rtmessage_git.bbappend
+++ b/recipes-common/rtmessage/rtmessage_git.bbappend
@@ -1,4 +1,4 @@
-CMF_GIT_BRANCH = "rdk-next"
-RDK_GIT_BRANCH = "stable2"
-
-DEPENDS_append = " rdk-logger"
+#To avoid build error due to RDKALL-2546
+do_install_append_broadband_dunfell () {
+	rm ${D}/usr/include/rbus-core
+}


### PR DESCRIPTION
…KALL-2546 changes

Reason for change: RDKC and RDKB using the same version & repo of rtMessage
    Test procedure: Tested with local build
    Risks: Low

Signed-off-by: Simon Chung <simon.c.chung@accenture.com>