### PR TITLE
Remove rtmessage recipe append

### DIFF
--- a/recipes-common/rtmessage/rtmessage_git.bbappend
+++ b/recipes-common/rtmessage/rtmessage_git.bbappend
@@ -1,4 +1,0 @@
-#To avoid build error due to RDKALL-2546
-do_install_append () {
-	rm -rf ${D}/usr/include/rbus-core
-}


### PR DESCRIPTION
The override is no longer needed, and causes build errors.