### PR TITLE
TDK-3816 : TDK Porting in Turris Omnia

### DIFF
--- a/recipes-core/images/rdk-generic-broadband-tdk-image.bbappend
+++ b/recipes-core/images/rdk-generic-broadband-tdk-image.bbappend
@@ -1,0 +1,45 @@
+inherit rdk-image
+
+IMAGE_FEATURES_remove = "read-only-rootfs"
+
+SYSTEMD_TOOLS = "systemd-analyze systemd-bootchart"
+# systemd-bootchart doesn't currently build with musl libc
+SYSTEMD_TOOLS_remove_libc-musl = "systemd-bootchart"
+
+IMAGE_INSTALL += " packagegroup-turris-core \
+    ${SYSTEMD_TOOLS} \
+    linux-firmware-ath10k \
+    network-hotplug \
+    php \
+    libmcrypt \
+    bzip2 \
+    nmap \
+    libpcap \
+    tcpdump \
+    ebtables \
+    iw \
+    ethtool \
+    bc \
+    mesh-agent \
+    opensync \
+    openvswitch \
+    "
+
+BB_HASH_IGNORE_MISMATCH = "1"
+IMAGE_NAME[vardepsexclude] = "DATETIME"
+
+#ESDK-CHANGES
+do_populate_sdk_ext_prepend() {
+    builddir = d.getVar('TOPDIR')
+    if os.path.exists(builddir + '/conf/templateconf.cfg'):
+        with open(builddir + '/conf/templateconf.cfg', 'w') as f:
+            f.write('meta/conf\n')
+}
+
+sdk_ext_postinst_append() {
+   echo "ln -s $target_sdk_dir/layers/openembedded-core/meta-rdk $target_sdk_dir/layers/openembedded-core/../meta-rdk \n" >> $env_setup_script
+}
+
+PRSERV_HOST = "localhost:0"
+INHERIT += "buildhistory"
+BUILDHISTORY_COMMIT = "1"

--- a/recipes-extended/tdkb/tdk-b.bbappend
+++ b/recipes-extended/tdkb/tdk-b.bbappend
@@ -1,0 +1,19 @@
+EXTRA_OECONF_append = " --enable-ert --enable-platform"
+
+SRC_URI += "${CMF_GIT_ROOT}/rdkb/devices/turris/tdkb;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};destsuffix=git/platform/turris;name=tdkbturris"
+
+SRCREV_tdkturris = "${AUTOREV}"
+do_fetch[vardeps] += "SRCREV_tdkbturris"
+SRCREV_FORMAT = "tdk_tdkbturris"
+
+do_install_append () {
+    install -d ${D}${tdkdir}
+    install -d ${D}/etc
+    install -p -m 755 ${S}/platform/turris/agent/scripts/*.sh ${D}${tdkdir}
+    install -p -m 755 ${S}/platform/turris/agent/scripts/tdk_platform.properties ${D}/etc/
+}
+
+FILES_${PN} += "${prefix}/ccsp/"
+FILES_${PN} += "/etc/*"
+FILES_${PN} += "${tdkdir}/*"
+


### PR DESCRIPTION
TDK-3816 : TDK Porting in Turris Omnia

Reason for change: Add TDK recipes for turris
Test Procedure:bitbake rdk-generic-broadband-tdk-image
Risks: None
Signed-off-by: svelusamy <svelusamy@tataelxsi.co.in>