### PR TITLE
Revert "Add BBMASKs needed for making Turris release builds."

### DIFF
--- a/conf/include/turris-bbmasks.inc
+++ b/conf/include/turris-bbmasks.inc
@@ -1,5 +1,4 @@
 BBMASK .= "|meta-rdk/recipes-core/packagegroups/packagegroup-rdk-media-common.bb"
-BBMASK .= "|meta-rdk/recipes-common/sys_mon_tools/cpuprocanalyzer_git.bb"
 
 BBMASK .= "|meta-rdk-ext/recipes-common/rtmessage"
 BBMASK .= "|meta-rdk-ext/recipes-support/base64/base64_git.bb"
@@ -14,5 +13,3 @@ BBMASK .= "${@'' if os.path.isdir('|meta-openembedded/meta-oe/recipes-devtools/b
 
 #To avoid build warning
 BBMASK .= "|meta-rdk-ext/recipes-support/iksemel/iksemel_1.5.bb"
-
-BBMASK .= "|meta-cmf/recipes-extended/rpcserver/"


### PR DESCRIPTION
Reverts rdkcentral/meta-turris#284

Fixed in meta-cmf-broadband instead