### PR TITLE
REFPLTB-1056: Resolve build issues for morty gateway build

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -60,8 +60,6 @@ do_install_append_class-target(){
     install -m 777 ${S}/systemd_units/scripts/utopiaInitCheck.sh ${D}/usr/ccsp/utopiaInitCheck.sh
     install -m 777 ${S}/systemd_units/scripts/ccspPAMCPCheck.sh ${D}/usr/ccsp/ccspPAMCPCheck.sh
 
-    install -m 777 ${S}/systemd_units/scripts/ProcessResetCheck.sh ${D}/usr/ccsp/ProcessResetCheck.sh
-    sed -i -e "s/source \/rdklogger\/logfiles.sh;syncLogs_nvram2/#source \/rdklogger\/logfiles.sh;syncLogs_nvram2/g" ${D}/usr/ccsp/ProcessResetCheck.sh
     # install systemd services
     install -d ${D}${systemd_unitdir}/system
     install -D -m 0644 ${S}/systemd_units/ccspwifiagent.service ${D}${systemd_unitdir}/system/ccspwifiagent.service
@@ -88,8 +86,6 @@ do_install_append_class-target(){
 
     install -D -m 0644 ${WORKDIR}/wifi-initialized.target ${D}${systemd_unitdir}/system/wifi-initialized.target
 
-    install -D -m 0644 ${S}/systemd_units/ProcessResetDetect.service ${D}${systemd_unitdir}/system/ProcessResetDetect.service
-    install -D -m 0644 ${S}/systemd_units/ProcessResetDetect.path ${D}${systemd_unitdir}/system/ProcessResetDetect.path
     install -D -m 0644 ${S}/systemd_units/logagent.service ${D}${systemd_unitdir}/system/logagent.service
 
     # Install wrapper for breakpad (disabled to support External Source build)
@@ -132,8 +128,6 @@ SYSTEMD_SERVICE_${PN} += "wifiinitialized.path"
 SYSTEMD_SERVICE_${PN} += "turriswifiinitialized.path"
 SYSTEMD_SERVICE_${PN} += "checkturriswifisupport.path"
 SYSTEMD_SERVICE_${PN} += "wifi-initialized.target"
-SYSTEMD_SERVICE_${PN} += "ProcessResetDetect.path"
-SYSTEMD_SERVICE_${PN} += "ProcessResetDetect.service"
 SYSTEMD_SERVICE_${PN} += "logagent.service"
 SYSTEMD_SERVICE_${PN} += "rfc.service"
 
@@ -142,7 +136,6 @@ FILES_${PN}_append = " \
     /usr/ccsp/ccspSysConfigLate.sh \
     /usr/ccsp/utopiaInitCheck.sh \
     /usr/ccsp/ccspPAMCPCheck.sh \
-    /usr/ccsp/ProcessResetCheck.sh \
     ${systemd_unitdir}/system/ccspwifiagent.service \
     ${systemd_unitdir}/system/CcspCrSsp.service \
     ${systemd_unitdir}/system/CcspPandMSsp.service \
@@ -159,8 +152,6 @@ FILES_${PN}_append = " \
     ${systemd_unitdir}/system/turriswifiinitialized.path \
     ${systemd_unitdir}/system/checkturriswifisupport.path \
     ${systemd_unitdir}/system/wifi-initialized.target \
-    ${systemd_unitdir}/system/ProcessResetDetect.path \
-    ${systemd_unitdir}/system/ProcessResetDetect.service \
     ${systemd_unitdir}/system/logagent.service \
     ${systemd_unitdir}/system/rfc.service \
 "

--- a/recipes-ccsp/util/utopia/0001-fix-lan-handler-for-turris.patch
+++ b/recipes-ccsp/util/utopia/0001-fix-lan-handler-for-turris.patch
@@ -1,31 +1,8 @@
-From 9cfe9b080409315cc9057459aa34d28f35334b6b Mon Sep 17 00:00:00 2001
-From: Simon Chung <simon.c.chung@accenture.com>
-Date: Tue, 9 Mar 2021 11:56:00 +0000
-Subject: [PATCH] Refresh of the patch originally added by:
-
-  d46de29 RDKCMF-3935 Modify gwprovapp state machine for Raspberry Pi events
-  d9a1ea9 RDKCMF-3919: RDK-B on RPI: update Utopia lan_handler sh patch
-  3ab4cf5 RDKCMF-3804 - Initial check-in for RDK-B on Raspberry Pi 2 and 3
-
-Since the previous version of the patch did not contain any diff
-context, it was being applied at a fixed offset in lan_handler.sh.
-That fixed offset has become incorrect as lan_handler.sh has been
-updated.
-
-Unfortunately none of the commits which previously added or updated
-the patch give any indication of what the patch does or why it's
-needed.
-
-Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
----
- source/scripts/init/service.d/lan_handler.sh | 18 ++++++++++++++++++
- 1 file changed, 18 insertions(+)
-
 diff --git a/source/scripts/init/service.d/lan_handler.sh b/source/scripts/init/service.d/lan_handler.sh
-index 7fd1b46c..4e95ed54 100755
+index 7d9fdd73d..fa0b8b351 100755
 --- a/source/scripts/init/service.d/lan_handler.sh
 +++ b/source/scripts/init/service.d/lan_handler.sh
-@@ -284,6 +284,24 @@ case "$1" in
+@@ -279,6 +279,24 @@ case "$1" in
              sysevent set multinet-up 9
          fi
  
@@ -47,9 +24,6 @@ index 7fd1b46c..4e95ed54 100755
 +        # Turris Omnia specific change end
 +        # --------------------------------------------------------------------
 +
-         echo_t "LAN HANDLER : Triggering RDKB_FIREWALL_RESTART after nfqhandler"
- 	t2CountNotify "SYS_SH_RDKB_FIREWALL_RESTART"
+         echo_t "LAN HANDLER : Triggering RDKB_FIREWALL_RESTART after nfqhandler" 
          sysevent set firewall-restart 
--- 
-2.28.0
-
+         uptime=`cat /proc/uptime | awk '{ print $1 }' | cut -d"." -f1`


### PR DESCRIPTION
Reason for change: To avoid build time errors with the branch rdkb-2021q1
Test Procedure: build and test
Risks: Low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>