### PR TITLE
Add ppp 2.4.8 recipe append

### DIFF
--- a/recipes-connectivity/ppp/ppp_2.4.8.bbappend
+++ b/recipes-connectivity/ppp/ppp_2.4.8.bbappend
@@ -1,0 +1,1 @@
+DEPENDS_remove = "virtual/crypt"


### PR DESCRIPTION
Remove dependency on virtual/crypt where it is only
available from musl in Turris.
Turris broadband build is currently on glibc.
ppp 2.4.8 has been added by meta-rdk-ext/55757.