### PR TITLE
Add nanomsg dependency to ppp

### DIFF
--- a/recipes-connectivity/ppp/ppp_2.4.8.bbappend
+++ b/recipes-connectivity/ppp/ppp_2.4.8.bbappend
@@ -1,0 +1,1 @@
+DEPENDS_remove = "virtual/crypt"

--- a/recipes-connectivity/ppp/ppp_2.4.8.bbappend
+++ b/recipes-connectivity/ppp/ppp_2.4.8.bbappend
@@ -1,1 +1,3 @@
 DEPENDS_remove = "virtual/crypt"
+
+SRC_URI_remove_extender = "file://ipc-event.patch"

--- a/recipes-connectivity/ppp/ppp_2.4.8.bbappend
+++ b/recipes-connectivity/ppp/ppp_2.4.8.bbappend
@@ -1,3 +1,4 @@
 DEPENDS_remove = "virtual/crypt"
+DEPENDS_append = " nanomsg"
 
 SRC_URI_remove_extender = "file://ipc-event.patch"


### PR DESCRIPTION
This is due to the ipc-event.patch adding dependency on nanomsg.