### PR TITLE
Fix Extender dunfell build

### DIFF
--- a/recipes-connectivity/ppp/ppp_2.4.8.bbappend
+++ b/recipes-connectivity/ppp/ppp_2.4.8.bbappend
@@ -1,5 +1,5 @@
 DEPENDS_remove = "virtual/crypt"
 DEPENDS_append = " nanomsg"
-DEPENDS_append_dunfell = " libxcrypt"
+DEPENDS_append_broadband_dunfell = " libxcrypt"
 
 SRC_URI_remove_extender = "file://ipc-event.patch"


### PR DESCRIPTION
This fixes the extender build error:
libxcrypt was skipped: PREFERRED_PROVIDER_virtual/crypt set to musl, not libxcrypt
due to extender is built with musl instead of glibc.
So specifying the libxcrypt dependency is only applicable to
broadband gateway.