### PR TITLE
Fix ccsp-wifi-agent build errors after warnings are treated as errors

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-wifi-agent.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-wifi-agent.bbappend
@@ -5,6 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 LDFLAGS += " \
 	-lutopiautil \
 	   "
+CFLAGS_append = " -Wno-error"
 
 #work around for wifi restart_flag=false, for meshagent synchroniztaion
 do_configure_prepend() {


### PR DESCRIPTION
Due to meta-rdk-broadband/55979.
The build error is
| ../../../../../../../../../../rdkb/components/opensource/ccsp/CcspWifiAgent/source/TR-181/sbapi/cosa_wifi_sbapi_custom.h:84:0: error: COSA_DML_WIFI_FEATURE_LoadPsmDefaults redefined [-Werror]
|  #define COSA_DML_WIFI_FEATURE_LoadPsmDefaults       0
|
| <command-line>:0:0: note: this is the location of the previous definition

In Turris build COSA_DML_WIFI_FEATURE_LoadPsmDefaults is turned on by recipe, so the
only way to fix this error is to add -Wno-error