### PR TITLE
removed python-core package from packagegroup

### DIFF
--- a/recipes-core/packagegroups/packagegroup-turris-core.bb
+++ b/recipes-core/packagegroups/packagegroup-turris-core.bb
@@ -34,7 +34,6 @@ RDEPENDS_packagegroup-turris-core = " \
    openssh \
    openssl \
    rpcbind \
-   python-core \
    sg3-utils \
    squashfs-tools \
    valgrind \


### PR DESCRIPTION
Reason for Change :to obtain the image size reduction
Test Procure: test the image on turris omnia board
Risk: None

Signed-off-by: Dhanunjaya-rama <biguvurama.dhanunjaya@ltts.com>