### PR TITLE
RDKB-33062: Fix warnings in EthWan

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-gwprovapp-ethwan.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-gwprovapp-ethwan.bbappend
@@ -7,8 +7,9 @@ inherit systemd
 DEPENDS_remove_dunfell = "hal-gwprovappabs"
 DEPENDS_append_dunfell = " breakpad-wrapper rdk-logger utopia"
 
-
 LDFLAGS_remove_dunfell = "-lgwprovappabs"
+
+CFLAGS_append = " -Wno-unused-variable -Wno-sizeof-pointer-memaccess -Wno-unused-parameter -Wno-unused-but-set-variable "
 
 do_install_append () {
 	install -d ${D}${systemd_unitdir}/system


### PR DESCRIPTION
Reason for change: to solve build warnings

Test Procedure: to test basic functionalities
Risks: Medium

Signed-off-by: Simon Chung <simon.c.chung@accenture.com>