### PR TITLE
RDKB-33031: Fix warnings for Utopia

### DIFF
--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -22,6 +22,8 @@ LDFLAGS_append = " \
     -lsecure_wrapper \
 "
 
+CFLAGS_append = " -Wno-format-extra-args -Wno-error "
+
 # we need to patch to code for Turris
 do_turris_patches() {
     cd ${S}


### PR DESCRIPTION
Reason for change: Enabling flags for solving warnings in Utopia.
Test Procedure: Build should be successful and warnings should be resolved.
Risks: High

Signed-off-by: Simon Chung <simon.c.chung@accenture.com>