### PR TITLE
Fix u-boot-turris SRCREV

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fw-utils-turris_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-fw-utils-turris_2019.07.bb
@@ -13,7 +13,7 @@ SRC_URI = " \
 SRC_URI += "file://fw_env.config"
 
 SRCBRANCH = "omnia-2019"
-SRCREV = "${AUTOREV}"
+SRCREV = "c3cbc14686bbc97a60a72b5dc7d5749b0cce8fbe"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-bsp/u-boot/u-boot-turris_2019.07.bb
+++ b/recipes-bsp/u-boot/u-boot-turris_2019.07.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
 "
 
 SRCBRANCH = "omnia-2019"
-SRCREV = "${AUTOREV}"
+SRCREV = "c3cbc14686bbc97a60a72b5dc7d5749b0cce8fbe"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
To c3cbc14686bbc97a60a72b5dc7d5749b0cce8fbe
Fixed SRCREV is better for release management of OSS components
and also allow for offline use of downloads cache.