### PR TITLE
RDKBCMF-276 Move hal turris device code to turris location

### DIFF
--- a/recipes-ccsp/hal/hal-dhcpv4c-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-dhcpv4c-generic_git.bbappend
@@ -1,9 +1,9 @@
-SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/dhcpv4c/devices;name=dhcphal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/dhcpv4c/devices_turris;name=dhcphal-turris"
 
 SRCREV_dhcphal-turris = "${AUTOREV}"
 
 do_configure_prepend(){
     rm ${S}/dhcpv4c_api.c
-    ln -sf ${S}/devices/source/dhcpv4c/dhcpv4c_api.c ${S}/dhcpv4c_api.c
+    ln -sf ${S}/devices_turris/source/dhcpv4c/dhcpv4c_api.c ${S}/dhcpv4c_api.c
 }
 

--- a/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
@@ -1,7 +1,7 @@
-SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/ethsw/devices;name=ethswhal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/ethsw/devices_turris;name=ethswhal-turris"
 
 SRCREV_ethswhal-turris = "${AUTOREV}"
 
 do_configure_prepend(){
-   ln -sf ${S}/devices/source/hal-ethsw/ccsp_hal_ethsw.c ${S}/ccsp_hal_ethsw.c
+   ln -sf ${S}/devices_turris/source/hal-ethsw/ccsp_hal_ethsw.c ${S}/ccsp_hal_ethsw.c
 }

--- a/recipes-ccsp/hal/hal-platform-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-platform-generic_git.bbappend
@@ -1,4 +1,4 @@
-SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/platform/devices;name=platformhal-turris"
+SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GITHUB_MASTER_BRANCH};destsuffix=git/source/platform/devices_turris;name=platformhal-turris"
 
 SRCREV = "${AUTOREV}"
 
@@ -9,5 +9,5 @@ CFLAGS_append = " \
 
 do_configure_prepend(){
     rm ${S}/platform_hal.c
-    ln -sf ${S}/devices/source/platform/platform_hal.c ${S}/platform_hal.c
+    ln -sf ${S}/devices_turris/source/platform/platform_hal.c ${S}/platform_hal.c
 }


### PR DESCRIPTION
The move allows multiple device specific hal code, turris and rpi.
to co-exists in EXTSRC workspaces.