### PR TITLE
Remove gtestapp from DISTRO_FEATURES

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,6 +14,8 @@ LAYERSERIES_COMPAT_turris = "dunfell"
 require conf/include/rdk-external-src-platform.inc
 
 DISTRO_FEATURES_append = " rdk-oss-ssa"
+
+DISTRO_FEATURES_remove = "gtestapp"
 DISTRO_FEATURES_remove_dunfell = "telemetry2_0"
 
 # RDKBDEV-73 : Dynamic DNS : Standardization based on broadband-forum.


### PR DESCRIPTION
gtestapp DISTRO_FEATURES causes rbus build errors in Turris.
It is enabled by meta-rdk/61401, but disabling it for Turris.