### PR TITLE
Remove rbus-core.bbappend

### DIFF
--- a/recipes-common/rbus-core/rbus-core.bbappend
+++ b/recipes-common/rbus-core/rbus-core.bbappend
@@ -1,3 +1,0 @@
-DEPENDS_dunfell += "msgpack-c glibc rtmessage"
-
-LDFLAGS_append = " -lrtMessage"


### PR DESCRIPTION
It is no longer requied. The contained overrides have
been added to the original recipe in meta-rdk.