### PR TITLE
Including hal-wifi-cfg80211 for hal-wifi in Turris-Omnia build

### DIFF
--- a/conf/machine/turris.conf
+++ b/conf/machine/turris.conf
@@ -31,7 +31,7 @@ PREFERRED_VERSION_xfsprogs = "4.8.0"
 PREFERRED_VERSION_php_dunfell = "7.1.%"
 PREFERRED_VERSION_php-native_dunfell = "7.1.%"
 
-PREFERRED_PROVIDER_hal-wifi = "hal-wifi-turris"
+PREFERRED_PROVIDER_hal-wifi = "hal-wifi-cfg80211"
 
 KERNEL_IMAGETYPE = "zImage"
 

--- a/recipes-connectivity/opensync/opensync_2.0.5.bbappend
+++ b/recipes-connectivity/opensync/opensync_2.0.5.bbappend
@@ -10,6 +10,6 @@ VENDOR_URI = "git://git@github.com/rdkcentral/opensync-vendor-rdk-turris.git;pro
 VENDOR_URI += "file://service.patch;patchdir=${WORKDIR}/git/"
 VENDOR_URI += "file://opensync.service"
 
-DEPENDS_append = " rdk-logger hal-wifi-turris"
+DEPENDS_append = " rdk-logger hal-wifi-cfg80211"
 
 RDK_CFLAGS += " -D_PLATFORM_TURRIS_"


### PR DESCRIPTION
REFPLTB-1290: Compiling the wifi-hal-cfg80211 recipe for turris-omnia and removing the wifi source from hal-wifi-turris

Reason for change: Building the common wifi-hal ie, hal-wifi-cfg80211 recipe rather than hal-wifi-turris
Test procedure: Build and Test
Risk: Low

Signed-off-by: kaviya.kumaresan <kaviya.kumaresan@ltts.com>