### PR TITLE
Enable bci_webui_jst

### DIFF
--- a/conf/machine/turris-bci.conf
+++ b/conf/machine/turris-bci.conf
@@ -9,3 +9,4 @@ MACHINEOVERRIDES .= ":bci"
 require turris.conf
 
 DISTRO_FEATURES_append = " bci"
+DISTRO_FEATURES_append = " bci_webui_jst"


### PR DESCRIPTION
in turris-bci machine config.
After meta-rdk-broadband/61031 is merged to enable
 ccsp-webui-bci jst instead of php.