### PR TITLE
Temporary disable zilker build until build issues are resolved.

### DIFF
--- a/recipes-core/packagegroups/packagegroup-rdk-oss-broadband.bbappend
+++ b/recipes-core/packagegroups/packagegroup-rdk-oss-broadband.bbappend
@@ -1,2 +1,2 @@
 RDEPENDS_packagegroup-rdk-oss-broadband_remove = "alljoyn"
-RDEPENDS_packagegroup-rdk-oss-broadband_append_dunfell = " zilker-sdk"
+#RDEPENDS_packagegroup-rdk-oss-broadband_append_dunfell = " zilker-sdk"


### PR DESCRIPTION
| CMake Error at buildTools/cmake/modules/AddZilkerAPI.cmake:52 (add_library):
|   No SOURCES given to target: xhBackupRestoreServiceAPI
| Call Stack (most recent call first):
|   source/services/backupRestore/api/c/CMakeLists.txt:26 (add_zilker_api)