### PR TITLE
Add override to use https instead of git protocol

### DIFF
--- a/recipes-connectivity/multiap-agent/multiap-agent_git.bb
+++ b/recipes-connectivity/multiap-agent/multiap-agent_git.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e1988ff7324cb957bcbf231f1bc6486c"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/TechnicolorEDGM/multiap_agent.git"
+SRC_URI = "git://github.com/TechnicolorEDGM/multiap_agent.git;protocol=https"
 
 SRCREV = "${AUTOREV}"
 

--- a/recipes-connectivity/multiap-controller/multiap-controller_git.bb
+++ b/recipes-connectivity/multiap-controller/multiap-controller_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=d5d0e19d5fa4af3f7d9817fb77a9bfb1"
 DEPENDS = "openssl libpcap"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/TechnicolorEDGM/multiap_controller.git"
+SRC_URI = "git://github.com/TechnicolorEDGM/multiap_controller.git;protocol=https"
 
 SRCREV = "${AUTOREV}"
 

--- a/recipes-connectivity/multiap-platform/multiap-platform_git.bb
+++ b/recipes-connectivity/multiap-platform/multiap-platform_git.bb
@@ -3,7 +3,7 @@ LICENSE = "BSD-2-Clause-Patent"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e1988ff7324cb957bcbf231f1bc6486c"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI = "git://github.com/TechnicolorEDGM/libmultiap_platform.git \
+SRC_URI = "git://github.com/TechnicolorEDGM/libmultiap_platform.git;protocol=https \
            file://0001-Makefile-changes.patch \
           "
 

--- a/recipes-protocols/ieee1905/ieee1905_git.bb
+++ b/recipes-protocols/ieee1905/ieee1905_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=9cbc6eb40e7e82d67fbbce1734e6622b"
 DEPENDS = "openssl libpcap multiap-platform"
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/TechnicolorEDGM/ieee1905.git \
+SRC_URI = "git://github.com/TechnicolorEDGM/ieee1905.git;protocol=https \
            file://0001-Added-support-for-RDK-flavour-compilation.patch \
           "
 #rdk-port: <TBD> need to apply following patch accordingly


### PR DESCRIPTION
The unauthenticated git protocol on port 9418 is no longer supported.