### PR TITLE
Remove redundant overrides for openssl-1.1.x-compatibility

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
@@ -4,9 +4,6 @@ require ccsp_common_turris.inc
 
 DEPENDS_append = " utopia curl "
 
-SRC_URI_remove_dunfell = "file://0001-openssl-1.1.x-compatibility-in-HMAC-functions.patch"
-
-
 CFLAGS_append = " \
     -I=${includedir}/utctx \
     -I=${includedir}/utapi \

--- a/recipes-ccsp/ccsp/ccsp-tr069-pa.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-tr069-pa.bbappend
@@ -3,9 +3,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 require ccsp_common_turris.inc
 LDFLAGS += "-Wl,--no-as-needed -lulog"
 
-SRC_URI_remove_dunfell = "file://0001-openssl-1.1.x-compatibility.patch"
-
-
 EXTRA_OECONF_append  = " --with-ccsp-arch=arm"
 
 LDFLAGS_append_dunfell = " -lsafec-3.5.1 -lcrypto"


### PR DESCRIPTION
They are no longer needed after the patches have been
removed by meta-rdk-broadband/63702