### PR TITLE
REFPLTB-1446: Create wic.bz2 image instead of wic.gz image

### DIFF
--- a/conf/machine/include/armada38x-base-turris.inc
+++ b/conf/machine/include/armada38x-base-turris.inc
@@ -8,7 +8,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
     kernel-devicetree \
     u-boot-script \
 "
-IMAGE_FSTYPES += "tar.bz2 ext2 wic.gz"
+IMAGE_FSTYPES += "tar.bz2 ext2 wic.bz2"
 SERIAL_CONSOLE = "115200 ttyS0"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-marvell"
 KERNEL_IMAGETYPE = "zImage"


### PR DESCRIPTION
Signed-off-by: Manigandan Gopalakrishnan <manigandan.gopalakrishnan@ltts.com>