### PR TITLE
RDKBDEV-773: Remove do_configure_append()

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-psm.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-psm.bbappend
@@ -2,10 +2,6 @@ require ccsp_common_turris.inc
 
 LDFLAGS_append_dunfell = " -lsafec-3.5.1"
 
-do_configure_append() {
-    install -m 644 ${S}/source-arm/psm_hal_apis.c -t ${S}/source/Ssp
-}
-
 do_install_append() {
     # Config files and scripts
     install -d ${D}/usr/ccsp/config


### PR DESCRIPTION
Reason for change:
Build failure is caused by do_configure_append() in meta-cmf-raspberrypi/recipes-ccsp/ccsp/ccsp-psm.bbappend.
The do_configure_append() seems to be unnecessary and should be removed.
Test Procedure: Sanity.
Risks: None.

Signed-off-by: Simon Chung <simon.c.chung@accenture.com>