### PR TITLE
REFPLTB-1464 : Blocklist mechanism for Nonroot process causing issues on RPI-B and Turris

### DIFF
--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -160,6 +160,8 @@ do_install_append() {
     echo 'echo_t "[utopia][init] completed creating utopia_inited flag"' >> ${D}${sysconfdir}/utopia/utopia_init.sh
     echo "touch -f /tmp/utopia_inited" >> ${D}${sysconfdir}/utopia/utopia_init.sh
 
+    sed -i '/log_capture_path.sh/a \
+mkdir -p \/opt\/secure ' ${D}${sysconfdir}/utopia/utopia_init.sh
 }
 
 do_install_append_dunfell() {


### PR DESCRIPTION
Reason for change: Added add-non-root-user-group.inc to create new user non-root
Test procedure: Tested in local build
Risks: None

Signed-off-by: Simon Chung <simon.c.chung@accenture.com>