### PR TITLE
RDKBDEV-780: drop obsolete support for reading ACS url

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-tr069-pa.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-tr069-pa.bbappend
@@ -16,7 +16,6 @@ do_install_append () {
     install -m 644 ${S}/config/ccsp_tr069_pa_cfg_arm.xml ${D}/usr/ccsp/tr069pa/ccsp_tr069_pa_cfg.xml
     install -m 644 ${S}/config/ccsp_tr069_pa_mapper_arm.xml ${D}/usr/ccsp/tr069pa/ccsp_tr069_pa_mapper.xml
     install -m 644 ${S}/config/sdm_arm.xml ${D}/usr/ccsp/tr069pa/sdm.xml
-    install -m 644 ${S}/arch/intel_usg/config/url ${D}/usr/ccsp/tr069pa/url
 
     install -d ${D}/fss/gw/
     install -d ${D}/fss/gw/usr/ccsp/

--- a/recipes-ccsp/util/utopia/posix-gwprovapp.patch
+++ b/recipes-ccsp/util/utopia/posix-gwprovapp.patch
@@ -1,11 +1,13 @@
---- git/source/syscfg/lib/Makefile.am	2019-03-19 10:02:19.740772177 +0000
-+++ git1/source/syscfg/lib/Makefile.am	2019-03-19 10:03:47.412200730 +0000
-@@ -21,7 +21,7 @@
+diff --git a/source/syscfg/lib/Makefile.am b/source/syscfg/lib/Makefile.am
+index 50d14ea2..8bfc3789 100644
+--- a/source/syscfg/lib/Makefile.am
++++ b/source/syscfg/lib/Makefile.am
+@@ -20,7 +20,7 @@ AM_CFLAGS = -D_ANSC_LINUX
+ AM_CFLAGS += -D_ANSC_USER
  AM_CFLAGS += -D_ANSC_LITTLE_ENDIAN_
- AM_CFLAGS += -fPIC
  AM_CFLAGS += -D_GNU_SOURCE
 -AM_CFLAGS += -DSC_POSIX_SEM
 +AM_CFLAGS += -DSC_SYSV_SEM
- AM_LDFLAGS = -L/var/tmp/pc-rdkb/lib
- AM_LDFLAGS += -lpthread
- AM_LDFLAGS += -lz
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ 


### PR DESCRIPTION
Reason for change:
drop obsolete support for reading ACS url from /usr/ccsp/tr069pa/url

Test Proedure: None.
Risks: None.
Signed-off-by: Murugan S <murugan_satishchandran@comcast.com>