### PR TITLE
WanManager support for Turris-omnia

### DIFF
--- a/conf/machine/turris.conf
+++ b/conf/machine/turris.conf
@@ -44,6 +44,7 @@ require conf/include/turris-bbmasks.inc
 
 DISTRO_FEATURES_append = " meshwifi"
 DISTRO_FEATURES_append = " ipv6"
+DISTRO_FEATURES_append = " rdkb_wan_manager"
 
 #for sdk support
 INHERIT_append = " uninative"

--- a/recipes-ccsp/ccsp/ccsp-cm-agent.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-cm-agent.bbappend
@@ -3,6 +3,8 @@ require ccsp_common_turris.inc
 DEPENDS_append_dunfell = " safec"
 LDFLAGS_append_dunfell = " -lsafec-3.5.1"
 
+EXTRA_OECONF_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '--enable-wanmgr', '', d)}"
+
 do_install_append() {
     # Config files and scripts
     install -m 644 ${S}/config-arm/CcspCMDM.cfg ${D}${prefix}/ccsp/cm/CcspCMDM.cfg

--- a/recipes-ccsp/ccsp/ccsp-common-library/utopia.service
+++ b/recipes-ccsp/ccsp/ccsp-common-library/utopia.service
@@ -1,0 +1,35 @@
+##########################################################################
+# If not stated otherwise in this file or this component's Licenses.txt
+# file the following copyright and licenses apply:
+#
+# Copyright 2021 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+[Unit]
+Description=Utopia service
+
+After=mount-nonvol.service
+
+[Service]
+Type=forking
+WorkingDirectory=/etc/utopia
+EnvironmentFile=/etc/device.properties
+ExecStartPre=/bin/sh -c '(/lib/rdk/wanip.sh &)'
+ExecStart=/bin/sh /etc/utopia/utopia_init.sh
+ExecStop=/bin/sh -c 'echo "Stopping/Restarting utopia_init.sh" >> ${PROCESS_RESTART_LOG}'
+
+StandardOutput=syslog+console
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-ccsp/ccsp/ccsp-cr.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-cr.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = " \
 do_install_append() {
     # Config files and scripts
     install -m 644 ${WORKDIR}/cr-deviceprofile_turris.xml ${D}/usr/ccsp/cr-deviceprofile.xml
+    install -m 644 ${WORKDIR}/cr-deviceprofile_turris.xml ${D}/usr/ccsp/cr-ethwan-deviceprofile.xml
 }
 
 LDFLAGS_append_dunfell = " -lpthread -lbreakpadwrapper"

--- a/recipes-ccsp/ccsp/ccsp-cr/cr-deviceprofile_turris.xml
+++ b/recipes-ccsp/ccsp/ccsp-cr/cr-deviceprofile_turris.xml
@@ -23,9 +23,11 @@
 	<component>
 		<name>com.cisco.spvtg.ccsp.pam</name> <version>1</version>
 	</component>
+<!--
 	<component>
 		<name>com.cisco.spvtg.ccsp.tr069pa</name> <version>1</version>
 	</component>
+-->
 	<component>
 		<name>com.cisco.spvtg.ccsp.tdm</name> <version>1</version>
 	</component>

--- a/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
@@ -21,6 +21,30 @@ CFLAGS_remove = "-Werror"
 
 EXTRA_OECONF_append  = " --with-ccsp-arch=arm"
 
+do_configure_prepend () {
+   #for WanManager support
+   #Below lines of code needs to be removed , once (Device.DHCPv4.Client.{i} and Device.DhCPv6,CLient.{i}) the mentioned parameters are permanently removed from TR181-USGv2.XML
+    DISTRO_WAN_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','rdkb_wan_manager','true','false',d)}"
+if [ $DISTRO_WAN_ENABLED = 'true' ]; then
+if [ ! -f ${WORKDIR}/WanManager_XML_UPDATED ]; then
+   GREP_WORD=`cat -n ${S}/config-arm/TR181-USGv2.XML  | grep 9536 | cut -d '<' -f2 | cut -d  '>' -f2`
+   if [ "$GREP_WORD" = "ClientNumberOfEntries" ]; then
+        #for DHCPv4.Client.{i}.
+        sed -i '9534s/<parameter>/<!-- <parameter>/g' ${S}/config-arm/TR181-USGv2.XML
+        sed -i '9542s/<\/parameter>/<\/parameter>-->/g' ${S}/config-arm/TR181-USGv2.XML
+        sed -i '9642s/<object>/<!-- <object>/g' ${S}/config-arm/TR181-USGv2.XML
+        sed -i '10058s/<\/object>/<\/object>-->/g' ${S}/config-arm/TR181-USGv2.XML
+        #for DHCPv6.Client.{i}.
+        sed -i '10832s/<parameter>/<!-- <parameter>/g' ${S}/config-arm/TR181-USGv2.XML
+        sed -i '10836s/<\/parameter>/<\/parameter>-->/g' ${S}/config-arm/TR181-USGv2.XML
+        sed -i '10839s/<object>/<!-- <object>/g' ${S}/config-arm/TR181-USGv2.XML
+        sed -i '11138s/<\/object>/<\/object>-->/g' ${S}/config-arm/TR181-USGv2.XML
+   fi
+   touch ${WORKDIR}/WanManager_XML_UPDATED
+fi
+fi
+}
+
 do_install_append(){
     # Config files and scripts
     install -m 644 ${S}/config-arm/CcspDmLib.cfg ${D}/usr/ccsp/pam/CcspDmLib.cfg

--- a/recipes-ccsp/ccsp/ccsp-psm.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-psm.bbappend
@@ -12,6 +12,41 @@ do_install_append() {
 #      <Record name="eRT.com.cisco.spvtg.ccsp.Device.WiFi.Radio.SSID.2.SSID" type="astr">TURRIS_RDKB-AP1</Record> \
 #      <Record name="eRT.com.cisco.spvtg.ccsp.Device.WiFi.Radio.SSID.1.Passphrase" type="astr">rdk@1234</Record> \
 #      <Record name="eRT.com.cisco.spvtg.ccsp.Device.WiFi.Radio.SSID.2.Passphrase" type="astr">rdk@1234</Record>' ${D}/usr/ccsp/config/bbhm_def_cfg.xml
+
+#WanManager Feature
+    DISTRO_WAN_ENABLED="${@bb.utils.contains('DISTRO_FEATURES','rdkb_wan_manager','true','false',d)}"
+    if [ $DISTRO_WAN_ENABLED = 'true' ]; then
+    sed -i '/AccessPoint.16.vAPStatsEnable/a \
+   <!-- rdkb-wanmanager related --> \
+   <Record name="dmsb.wanmanager.wanenable" type="astr">1</Record> \
+   <Record name="dmsb.wanmanager.wanifcount" type="astr">1</Record> \
+   <Record name="dmsb.wanmanager.wanpolicy" type="astr">2</Record> \ 
+   <Record name="dmsb.wanmanager.wanidletimeout" type="astr">0</Record> \
+   <Record name="dmsb.selfheal.rebootstatus"  type="astr">0</Record> \
+   <Record name="dmsb.wanmanager.if.1.Name" type="astr">eth2</Record> \
+   <Record name="dmsb.wanmanager.if.1.DisplayName" type="astr">WanOE</Record> \
+   <Record name="dmsb.wanmanager.if.1.Enable" type="astr">TRUE</Record> \
+   <Record name="dmsb.wanmanager.if.1.Type" type="astr">2</Record> \
+   <Record name="dmsb.wanmanager.if.1.Priority" type="astr">0</Record> \
+   <Record name="dmsb.wanmanager.if.1.SelectionTimeout" type="astr">0</Record> \
+   <Record name="dmsb.wanmanager.if.1.DynTriggerEnable" type="astr">FALSE</Record> \
+   <Record name="dmsb.wanmanager.if.1.DynTriggerDelay" type="astr">0</Record> \
+   <Record name="dmsb.wanmanager.if.1.Marking.List" type="astr">DATA</Record> \
+   <Record name="dmsb.wanmanager.if.1.Marking.DATA.Alias" type="astr">DATA</Record> \
+   <Record name="dmsb.wanmanager.if.1.Marking.DATA.SKBPort" type="astr">1</Record> \
+   <Record name="dmsb.wanmanager.if.1.Marking.DATA.SKBMark" type="astr"> </Record> \
+   <Record name="dmsb.wanmanager.if.1.Marking.DATA.EthernetPriorityMark" type="astr"></Record> \
+   <Record name="dmsb.wanmanager.if.1.PPPEnable" type="astr">FALSE</Record> \
+   <Record name="dmsb.wanmanager.if.1.PPPLinkType" type="astr">PPPoE</Record> \
+   <Record name="dmsb.wanmanager.if.1.PPPIPCPEnable" type="astr">TRUE</Record> \
+   <Record name="dmsb.wanmanager.if.1.PPPIPV6CPEnable" type="astr">TRUE</Record> \
+   <Record name="dmsb.wanmanager.if.1.PPPIPCPEnable" type="astr">TRUE</Record> \
+   <Record name="dmsb.wanmanager.if.1.ActiveLink" type="astr">TRUE</Record> \
+   <Record name="dmsb.wanmanager.if.1.EnableMAPT" type="astr">FALSE</Record> \
+   <Record name="dmsb.wanmanager.if.1.EnableDSLite" type="astr">FALSE</Record> \
+   <Record name="dmsb.wanmanager.if.1.EnableIPoEHealthCheck" type="astr">FALSE</Record> \
+   <Record name="dmsb.wanmanager.if.1.RebootOnConfiguration" type="astr">FALSE</Record>' ${D}/usr/ccsp/config/bbhm_def_cfg.xml
+    fi
 }
 
 LDFLAGS_append_dunfell = " -lpthread"

--- a/recipes-ccsp/ccsp/ccsp_common_turris.inc
+++ b/recipes-ccsp/ccsp/ccsp_common_turris.inc
@@ -6,6 +6,7 @@ CFLAGS_append += " -U_COSA_SIM_ -fno-exceptions -ffunction-sections -fdata-secti
            -D_ANSC_AES_USED_ -D_NO_EXECINFO_H_ -DFEATURE_SUPPORT_SYSLOG \
            -DBUILD_WEB -D_NO_ANSC_ZLIB_ -D_DEBUG -U_ANSC_IPV6_COMPATIBLE_ -DUSE_NOTIFY_COMPONENT \
            -D_PLATFORM_TURRIS_ -DENABLE_SD_NOTIFY -DCOSA_DML_WIFI_FEATURE_LoadPsmDefaults -UPARODUS_ENABLE -DENABLE_FEATURE_MESHWIFI"
+CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' -DFEATURE_RDKB_WAN_MANAGER ', '', d)}"
 
 DEPENDS += "breakpad-wrapper"
 LDFLAGS += "-lbreakpadwrapper"

--- a/recipes-ccsp/ccsp/files/wanip.sh
+++ b/recipes-ccsp/ccsp/files/wanip.sh
@@ -1,0 +1,12 @@
+##Added workaround fix for getting erouter0 ip
+loop=1
+sleep 20
+while [ $loop -eq 1 ];
+do
+temp=`ip addr show erouter0 |grep -i 'inet ' |awk '{print $2}' | cut -d '/' -f1`
+if [ "$temp" == "" ]; then
+killall udhcpc
+udhcpc -i erouter0 &
+fi
+sleep 60
+done

--- a/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
+++ b/recipes-ccsp/hal/hal-ethsw-generic_git.bbappend
@@ -2,6 +2,8 @@ SRC_URI += "${CMF_GITHUB_ROOT}/rdkb-turris-hal;protocol=${CMF_GIT_PROTOCOL};bran
 
 SRCREV_ethswhal-turris = "${AUTOREV}"
 
+CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"
+
 do_configure_prepend(){
    ln -sf ${S}/devices_turris/source/hal-ethsw/ccsp_hal_ethsw.c ${S}/ccsp_hal_ethsw.c
 }

--- a/recipes-ccsp/util/utopia/system_defaults
+++ b/recipes-ccsp/util/utopia/system_defaults
@@ -976,3 +976,9 @@ $dslite_tcpmss_1=1420
 
 #dslite_ipv6_frag_enable - Enable/disable dslite IPv6 frag
 $dslite_ipv6_frag_enable_1=0
+
+#Defaults for WanManager
+$tr_dhcpv6c_enabled=1
+$tr_dhcpv6c_iana_enabled=1
+$tr_dhcpv6c_iapd_enabled=1
+

--- a/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
+++ b/recipes-core/packagegroups/packagegroup-rdk-ccsp-broadband.bbappend
@@ -28,5 +28,7 @@ RDEPENDS_packagegroup-rdk-ccsp-broadband_remove_dunfell = "start-parodus"
 #TODO: need to revisit if it breaks functionality. removing since it depends on ucresolv
 #RDEPENDS_packagegroup-rdk-ccsp-broadband_remove = "parodus"
 
-GWPROVAPP = "ccsp-gwprovapp-ethwan"
+RDEPENDS_packagegroup-rdk-ccsp-broadband_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' rdk-wanmanager ', '', d)} "
+
+GWPROVAPP = ""
 

--- a/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -58,6 +58,8 @@ do_install_append() {
     sed -i "/uploadRDKBLogs.sh/a \ \t \t  \t  uploading_rdklogs" ${D}/rdklogger/rdkbLogMonitor.sh
     sed -i "/uploadRDKBLogs.sh/d " ${D}/rdklogger/rdkbLogMonitor.sh
     sed -i "/upload_nvram2_logs()/i uploading_rdklogs() \n { \n \ \t \t TFTP_RULE_COUNT=\`iptables -t raw -L -n | grep tftp | wc -l\` \n \ \t \t if [ \"\$TFTP_RULE_COUNT\" == 0 ] \n \t \t then \n \ \t \t \t iptables -t raw -I OUTPUT -j CT -p udp -m udp --dport 69 --helper tftp \n \ \t \t \t sleep 2 \n \ \t \t fi \n \ \t \t cd /nvram/logbackup \n \ \t \t FILENAME=\`ls *.tgz\` \n \ \t \t tftp -p -r \$FILENAME \$TFTP_SERVER_IP \n } " ${D}/rdklogger/rdkbLogMonitor.sh
+
+    install -m 0755 ${S}/devicerpi/lib/rdk/run_rm_key.sh   ${D}${base_libdir}/rdk
 }
 
 FILES_${PN} += "${systemd_unitdir}/system/swupdate.service"


### PR DESCRIPTION
REFPLTB-1505: Add necessary updates for WanManager support in meta-turris layer

Reason for change: Including the changes for wanmanager integeration
Test Procedure: Build and test
Risks: low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>