### PR TITLE
Update ccsp-eth-agent for wan-manager support

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-eth-agent.bbappend
@@ -2,6 +2,20 @@ require ccsp_common_turris.inc
 
 EXTRA_OECONF_append  = " --with-ccsp-arch=arm"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://include_platform_turris.patch;apply=no"
+
+# we need to patch to code for Turris
+do_turris_patches() {
+    cd ${S}
+    if [ ! -e patch_applied ]; then
+        patch -p1 < ${WORKDIR}/include_platform_turris.patch
+        touch patch_applied
+    fi
+}
+addtask turris_patches after do_unpack before do_compile
+
 LDFLAGS_append =" \
     -lsyscfg \
     -lbreakpadwrapper \

--- a/recipes-ccsp/ccsp/files/include_platform_turris.patch
+++ b/recipes-ccsp/ccsp/files/include_platform_turris.patch
@@ -1,0 +1,54 @@
+Signed-off-by: kaviya.kumaresan@ltts.com
+Subject: Including PLATFORM_TURRIS that supports the wan-manager integeration for Turris-Omnia
+
+diff --git a/source/TR-181/board_sbapi/cosa_ethernet_apis.c b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+index fd3d24b..dfa97b0 100644
+--- a/source/TR-181/board_sbapi/cosa_ethernet_apis.c
++++ b/source/TR-181/board_sbapi/cosa_ethernet_apis.c
+@@ -317,12 +317,14 @@ typedef enum WanMode
+ #define ETHWAN_DEF_INTF_NAME "eth5"
+ #elif defined (INTEL_PUMA7)
+ #define ETHWAN_DEF_INTF_NAME "nsgmii0"
++#elif defined (_PLATFORM_TURRIS_)
++#define ETHWAN_DEF_INTF_NAME "eth2"
+ #else
+ #define ETHWAN_DEF_INTF_NAME "eth0"
+ #endif
+ 
+ 
+-#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
++#if defined(_PLATFORM_RASPBERRYPI_) 
+ #define ETHWAN_DEF_INTF_NAME "eth0"
+ #endif
+ 
+@@ -1601,7 +1603,7 @@ CosaDmlEthInit(
+         }
+     }
+ #else
+-    #if defined(_PLATFORM_RASPBERRYPI_)
++    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
+     char wanPhyName[20] = {0},out_value[20] = {0};
+ 
+     if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
+diff --git a/source/TR-181/board_sbapi/cosa_ethernet_manager.c b/source/TR-181/board_sbapi/cosa_ethernet_manager.c
+index 3c70853..02e5b74 100644
+--- a/source/TR-181/board_sbapi/cosa_ethernet_manager.c
++++ b/source/TR-181/board_sbapi/cosa_ethernet_manager.c
+@@ -21,7 +21,7 @@
+ /* ---- Include Files ---------------------------------------- */
+ #include "cosa_ethernet_manager.h"
+ #include "cosa_ethernet_apis.h"
+-#if defined(_PLATFORM_RASPBERRYPI_)
++#if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)
+ #include "syscfg.h"
+ #endif
+ 
+@@ -329,7 +329,7 @@ static ethSmState_t Transition_EthWanLinkFound(PETH_SM_PRIVATE_INFO pstInfo)
+ #if defined(FEATURE_RDKB_WAN_AGENT)
+     if (ANSC_STATUS_SUCCESS != CosaDmlEthCreateEthLink(pstInfo->Name, stGlobalInfo.Path))
+ #elif defined(FEATURE_RDKB_WAN_MANAGER)
+-    #if defined(_PLATFORM_RASPBERRYPI_)     
++    #if defined(_PLATFORM_RASPBERRYPI_) || defined(_PLATFORM_TURRIS_)     
+     CHAR wanPhyName[20] = {0},out_value[20] = {0};
+     if (!syscfg_get(NULL, "wan_physical_ifname", out_value, sizeof(out_value)))
+     {


### PR DESCRIPTION
REFPLTB-1505: Add necessary updates for WanManager support in meta-turris layer

Reason for change: Including the changes for wanmanager integeration
Test Procedure: Build and test
Risks: low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>