### PR TITLE
Add sysint-broadband SRC_URI_append for devicerpi

### DIFF
--- a/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -1,3 +1,9 @@
+SRC_URI_append = " \
+    ${CMF_GIT_ROOT}/rdkb/devices/raspberrypi/sysint;module=.;protocol=${CMF_GIT_PROTOCOL};branch=${CMF_GIT_BRANCH};destsuffix=git/devicerpi;name=sysintdevicerpi \
+"
+SRCREV_sysintdevicerpi = "${AUTOREV}"
+SRCREV_FORMAT = "sysintgeneric_sysintdevicerpi"
+
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRCREV_FORMAT = "${AUTOREV}"


### PR DESCRIPTION
It is needed to fetch the run_rm_key.sh script for installation.