### PR TITLE
scp sending files does not work in Turris-omnia

### DIFF
--- a/recipes-connectivity/hostapd/files/hostapd-init.sh
+++ b/recipes-connectivity/hostapd/files/hostapd-init.sh
@@ -207,5 +207,8 @@ ifconfig lan2 up
 ifconfig lan3 up
 ifconfig lan4 up
 
+#workaround: creating /opt/secure folder for ssh service
+mkdir /opt/secure
+
 exit 0
 


### PR DESCRIPTION
REFPLTB-1531: scp sending files does not work in Turris-omnia

Reason for change: scp sending files does not work
Test Procedure: Flash the image and test
Risk: None

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>