### PR TITLE
RDKBDEV-780: drop obsolete support for reading ACS url

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-tr069-pa.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-tr069-pa.bbappend
@@ -13,7 +13,6 @@ do_install_append () {
     install -m 644 ${S}/config/ccsp_tr069_pa_cfg_arm.xml ${D}/usr/ccsp/tr069pa/ccsp_tr069_pa_cfg.xml
     install -m 644 ${S}/config/ccsp_tr069_pa_mapper_arm.xml ${D}/usr/ccsp/tr069pa/ccsp_tr069_pa_mapper.xml
     install -m 644 ${S}/config/sdm_arm.xml ${D}/usr/ccsp/tr069pa/sdm.xml
-    install -m 644 ${S}/arch/intel_usg/config/url ${D}/usr/ccsp/tr069pa/url
 
     install -d ${D}/fss/gw/
     install -d ${D}/fss/gw/usr/ccsp/


### PR DESCRIPTION
Reason for change:
drop obsolete support for reading ACS url from /usr/ccsp/tr069pa/url

Test Proedure: None.
Risks: None.

Signed-off-by: Simon Chung <simon.c.chung@accenture.com>