### PR TITLE
Avoid do_patch issues with ccsp-wifi-agent

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-wifi-agent.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-wifi-agent.bbappend
@@ -30,7 +30,7 @@ do_turris_ccspwifiagent_patches() {
     if [ ! -e patch_applied ]; then
         bbnote "Patching handle_mesh-rename-opensync.patch"
         patch  -p1 < ${WORKDIR}/handle_mesh-rename-opensync.patch ${S}/scripts/handle_mesh
-        patch  -p1 < ${WORKDIR}/avoid_gssidcount_error.patch 
+        patch  -p1 < ${WORKDIR}/avoid_gssidcount_error.patch || echo "ERROR or Patch already applied"
         touch patch_applied
     fi
 }


### PR DESCRIPTION
REFPLTB-1457: Building wifi hal code with WIFI_HAL_VERSION_3 for Turris Omnia

Reason for change: To avoid ccsp-wifi-agent related errors with wifi_hal3.0
Test Procedure: Build and Test
Risks: Low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>