### PR TITLE
REFPLTB-1585:procps update for ip_forward in sysctl.conf

### DIFF
--- a/recipes-extended/procps/procps_%.bbappend
+++ b/recipes-extended/procps/procps_%.bbappend
@@ -1,0 +1,4 @@
+do_install_append () {
+sed -i "s/#net\/ipv4\/ip_forward=1/net\/ipv4\/ip_forward=1/g" ${D}/etc/sysctl.conf
+}
+


### PR DESCRIPTION
Reason for change: Requires ip_forward=1 in sysctl.conf for both turris-gateway and turris-extender
Test Procedure: Build and Test
Risks: low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>