### PR TITLE
REFPLTB-1633: Add preferred provider of wifi HAL to turris-extender

### DIFF
--- a/conf/machine/turris-extender.conf
+++ b/conf/machine/turris-extender.conf
@@ -32,6 +32,7 @@ PREFERRED_VERSION_linux-libc-headers = "4.14.22"
 PREFERRED_VERSION_xfsprogs = "4.8.0"
 PREFERRED_VERSION_php = "7.1.%"
 PREFERRED_VERSION_php-native = "7.1.%"
+PREFERRED_PROVIDER_hal-wifi = "hal-wifi-cfg80211"
 
 KERNEL_IMAGETYPE = "zImage"
 


### PR DESCRIPTION
Add missing preferred provider of wifi HAL to Turris Omnia Extender
machine config. It is already present in Turris Omnia GW config.
