### PR TITLE
REFPLTB-1670: Fix swupdate.service being added to SYSTEMD_SERVICE

### DIFF
--- a/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -27,7 +27,7 @@ SRC_URI += "file://commonUtils.sh \
             file://dcm-log.service"
 
 SYSTEMD_SERVICE_${PN} = "swupdate.service"
-SYSTEMD_SERVICE_${PN} = "dcm-log.service"
+SYSTEMD_SERVICE_${PN} += "dcm-log.service"
 
 do_install_append() {
     echo "BOX_TYPE=turris" >> ${D}${sysconfdir}/device.properties


### PR DESCRIPTION
dcm-log.service was assigned to SYSTEMD_SERVICE_${PN} instead of being
appended to it. It resulted in swupdate.service never reaching this
variable and hence not being started on boot.

Signed-off-by: Piotr Nakraszewicz <piotr.nakraszewicz@consult.red>
Signed-off-by: Piotr Nakraszewicz <pnakraszewicz@plume.com>