### PR TITLE
REFPLTB-1671: Unify flashing outcome

### DIFF
--- a/recipes-connectivity/hostapd/files/hostapd-init.sh
+++ b/recipes-connectivity/hostapd/files/hostapd-init.sh
@@ -25,18 +25,6 @@ then
 sleep 5;
 fi
 
-nvram_mounted=`mount | grep nvram -wc`
-if [ $nvram_mounted == 0 ]; then
-	mkdir -p /nvram
-	if [ -b /dev/mmcblk0p6 ]; then
-		#for Older Turris Omnia
-		mount /dev/mmcblk0p6 /nvram
-	else
-		#for Omnia2019 and  Omnia2020
-		mount /dev/mmcblk0p5 /nvram
-	fi
-fi
-
 WIFI0_MAC=`cat /sys/class/net/wlan0/address`
 WIFI1_MAC=`cat /sys/class/net/wlan1/address`
 echo "2.4GHz Radio MAC: $WIFI0_MAC"

--- a/recipes-connectivity/hostapd/files/hostapd.service
+++ b/recipes-connectivity/hostapd/files/hostapd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Hostapd IEEE 802.11n AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator
 After=CcspPandMSsp.service
+RequiresMountsFor=/nvram
 StartLimitIntervalSec=120
 
 [Service]

--- a/recipes-rdkb/sysint-broadband/files/nvram.mount
+++ b/recipes-rdkb/sysint-broadband/files/nvram.mount
@@ -1,0 +1,9 @@
+[Unit]
+Before=local-fs.target
+
+[Mount]
+Where=/nvram
+What=/dev/disk/by-label/nvram1
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
+++ b/recipes-rdkb/sysint-broadband/sysint-broadband.bbappend
@@ -13,6 +13,7 @@ SRC_URI_remove = "${CMF_GIT_ROOT}/rdkb/devices/intel-x86-pc/emulator/sysint;modu
 SRC_URI += "file://TurrisFwUpgrade.sh"
 SRC_URI += "file://swupdate_utility.sh"
 SRC_URI += "file://swupdate.service"
+SRC_URI += "file://nvram.mount"
 SRC_URI += "file://commonUtils.sh \
             file://dcaSplunkUpload.sh \
             file://dca_utility.sh \
@@ -28,6 +29,7 @@ SRC_URI += "file://commonUtils.sh \
 
 SYSTEMD_SERVICE_${PN} = "swupdate.service"
 SYSTEMD_SERVICE_${PN} += "dcm-log.service"
+SYSTEMD_SERVICE_${PN} += "nvram.mount"
 
 do_install_append() {
     echo "BOX_TYPE=turris" >> ${D}${sysconfdir}/device.properties
@@ -37,6 +39,7 @@ do_install_append() {
     install -m 0755 ${WORKDIR}/TurrisFwUpgrade.sh ${D}${base_libdir}/rdk
     install -m 0755 ${WORKDIR}/swupdate_utility.sh ${D}${base_libdir}/rdk
     install -m 0644 ${WORKDIR}/swupdate.service ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/nvram.mount ${D}${systemd_unitdir}/system
     echo "CLOUDURL="http://35.155.171.121:9092/xconf/swu/stb?eStbMac="" >> ${D}${sysconfdir}/include.properties
 
     #DCM simulator Support
@@ -70,5 +73,6 @@ do_install_append() {
 
 FILES_${PN} += "${systemd_unitdir}/system/swupdate.service"
 FILES_${PN} += "${systemd_unitdir}/system/dcm-log.service"
+FILES_${PN} += "${systemd_unitdir}/system/nvram.mount"
 
 RDEPENDS_${PN}_append_dunfell = " bash"

--- a/scripts/lib/wic/canned-wks/rdk-generic-broadband-image.turris.wks
+++ b/scripts/lib/wic/canned-wks/rdk-generic-broadband-image.turris.wks
@@ -1,9 +1,17 @@
 # short-description: Create mmc image for Turris Omnia
 # long-description: Creates a partitioned mmc image for use with
 # Turris Omnia. Boot files are located in the first vfat partition.
+# Make the partitions as big as possible so that future software upgrades
+# that don't modify the partition sizes (using TurrisFwUpgrade.sh) can be
+# performed without issues even if rootfs increases in the future.
+# Sizes of all partitions sum up to be less then 1000MB, so that the
+# resulting image fits into tmpfs of medkit image that does the flasing.
 
-part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 1024 --system-id 0x0c
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label primary --align 1024
-part /secondary --source rootfs --ondisk mmcblk0 --fstype=ext4 --label secondary --align 1024 --fsoptions "noauto"
-part /nvram --ondisk mmcblk0 --fstype=ext4 --label nvram1 --align 1024 --fixed-size 100M
-part /nvram2 --ondisk mmcblk0 --fstype=ext4 --label nvram2 --align 1024 --fixed-size 100M --fsoptions "noauto"
+# boot
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 1024 --system-id 0x0c --fixed-size 40M
+# rootfs
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label primary --align 1024 --fixed-size 316M
+# secondary rootfs
+part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label secondary --align 1024 --fixed-size 316M
+# nvram
+part --ondisk mmcblk0 --fstype=ext4 --label nvram1 --align 1024 --fixed-size 316M


### PR DESCRIPTION
There are two ways to flash the Turris:
- using USB drive
- using TurrisFwUpgrade.sh script

However they resulted in different outcome:
- different /etc/fstab
- nvram mounted on either:
  - /dev/mmcblk0p5 as a result of fstab entry
  - /dev/mmcblk0p6 mounted by hostapd-init.sh

Unify and optimize the outcome:
- Remove /nvram mounting code from hostapd-init.sh and just require that
  the service is started when /nvram is already mounted.
- Remove nvram2 partition which is not used anyway, use the extra space
  to increase the size of other partitions
- Unify the partition layout. Remove the legacy NewTurrisModel=0 variant
  from TurrisFwUpgrade.sh
- Don't update the /etc/fstab when creating the wic image / flashing
  from USB
- Use designated systemd mount unit for mounting /nvram based on the
  label

Signed-off-by: Piotr Nakraszewicz <piotr.nakraszewicz@consult.red>
Signed-off-by: Piotr Nakraszewicz <pnakraszewicz@plume.com>