### PR TITLE
REFPLTB-1643: Turris GW - not getting erouter0 IP on most boots (#411)

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -115,7 +115,7 @@ do_install_append_class-target(){
      if [ $DISTRO_WAN_ENABLED = 'true' ]; then
      install -D -m 0644 ${S}/systemd_units/RdkWanManager.service ${D}${systemd_unitdir}/system/RdkWanManager.service
      sed -i "/WorkingDirectory/a ExecStartPre=/bin/sh /lib/rdk/run_rm_key.sh" ${D}${systemd_unitdir}/system/RdkWanManager.service
-     sed -i "s/After=CcspCrSsp.service/After=CcspCrSsp.service utopia.service/g" ${D}${systemd_unitdir}/system/RdkWanManager.service
+     sed -i "s/After=CcspCrSsp.service/After=CcspCrSsp.service utopia.service PsmSsp.service CcspEthAgent.service/g" ${D}${systemd_unitdir}/system/RdkWanManager.service
      sed -i "s/CcspPandMSsp.service/CcspCrSsp.service CcspPandMSsp.service/g" ${D}${systemd_unitdir}/system/CcspEthAgent.service
      install -D -m 0644 ${WORKDIR}/utopia.service ${D}${systemd_unitdir}/system/utopia.service
      install -D -m 0644 ${S}/systemd_units/RdkTelcoVoiceManager.service ${D}${systemd_unitdir}/system/RdkTelcoVoiceManager.service


### PR DESCRIPTION
Reason for change: Adding necessary dependant service for RdkWanManager service
Test procedure: erouter0 interface is getting IP after multiple reboots
Risks: None

Signed-off-by: Manigandan Gopalakrishnan <manigandan.gopalakrishnan@ltts.com>