### PR TITLE
REFPLTB-1693: add support for open WiFi networks

### DIFF
--- a/recipes-connectivity/hostapd/files/hostapd-init.sh
+++ b/recipes-connectivity/hostapd/files/hostapd-init.sh
@@ -130,7 +130,6 @@ then
         sed -i "/^bssid=/c\bssid=$NEW_MAC" /nvram/hostapd8.conf
         sed -i "/^interface=/c\interface=wifi8" /nvram/hostapd8.conf
         sed -i "/^accept_mac/c\accept_mac_file=/tmp/hostapd-acl8"  /nvram/hostapd8.conf
-        echo "wpa_psk_file=/tmp/hostapd8.psk" >> /nvram/hostapd8.conf
 fi
 
 if [ ! -f /nvram/hostapd9.conf ]
@@ -141,7 +140,6 @@ then
         sed -i "/^bssid=/c\bssid=$NEW_MAC" /nvram/hostapd9.conf
         sed -i "/^interface=/c\interface=wifi9" /nvram/hostapd9.conf
         sed -i "/^accept_mac/c\accept_mac_file=/tmp/hostapd-acl9"  /nvram/hostapd9.conf
-        echo "wpa_psk_file=/tmp/hostapd9.psk" >> /nvram/hostapd9.conf
 fi
 
 #Setting up VAP status file
@@ -150,6 +148,9 @@ echo -e "wifi0=1\nwifi1=1\nwifi2=0\nwifi3=0\nwifi4=0\nwifi5=0\nwifi6=0\nwifi7=0\
 #Creating files for tracking AssociatedDevices
 touch /tmp/AllAssociated_Devices_2G.txt
 touch /tmp/AllAssociated_Devices_5G.txt
+
+#workaround: creating /opt/secure folder for ssh service
+mkdir /opt/secure
 
 if [ $device_type == "extender" ];
 then
@@ -236,9 +237,6 @@ ifconfig lan1 up
 ifconfig lan2 up
 ifconfig lan3 up
 ifconfig lan4 up
-
-#workaround: creating /opt/secure folder for ssh service
-mkdir /opt/secure
 
 exit 0
 

--- a/recipes-connectivity/hostapd/hostapd_2.9.bb
+++ b/recipes-connectivity/hostapd/hostapd_2.9.bb
@@ -16,6 +16,8 @@ SRC_URI = " \
     file://defconfig \
     file://hostapd-2G.conf \
     file://hostapd-5G.conf \
+    file://hostapd-open2G.conf \
+    file://hostapd-open5G.conf \
     file://hostapd-bhaul2G.conf \
     file://hostapd-bhaul5G.conf \
     file://hostapd.service \
@@ -52,6 +54,8 @@ do_install() {
          install -m 0755 ${B}/hostapd_cli ${D}${sbindir}
          install -m 0644 ${WORKDIR}/hostapd-2G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd-5G.conf ${D}${sysconfdir}
+         install -m 0644 ${WORKDIR}/hostapd-open2G.conf ${D}${sysconfdir}
+         install -m 0644 ${WORKDIR}/hostapd-open5G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd-bhaul2G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd-bhaul5G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd.service ${D}${systemd_unitdir}/system
@@ -66,6 +70,8 @@ do_install_turris-extender() {
          sed -i '/^ExecStart=/c\ExecStart=/usr/sbin/hostapd -g /var/run/hostapd/global -B -P /var/run/hostapd-global.pid' ${WORKDIR}/hostapd.service
          install -m 0644 ${WORKDIR}/hostapd-2G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd-5G.conf ${D}${sysconfdir}
+         install -m 0644 ${WORKDIR}/hostapd-open2G.conf ${D}${sysconfdir}
+         install -m 0644 ${WORKDIR}/hostapd-open5G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd-bhaul2G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd-bhaul5G.conf ${D}${sysconfdir}
          install -m 0644 ${WORKDIR}/hostapd.service ${D}${systemd_unitdir}/system
@@ -76,6 +82,8 @@ FILES_${PN} += " \
                 ${systemd_unitdir}/system/hostapd.service \
                 ${sysconfdir}/hostapd-2G.conf \
                 ${sysconfdir}/hostapd-5G.conf \
+                ${sysconfdir}/hostapd-open2G.conf \
+                ${sysconfdir}/hostapd-open5G.conf \
                 ${sysconfdir}/hostapd-bhaul2G.conf \
                 ${sysconfdir}/hostapd-bhaul5G.conf \
                 ${base_libdir}/rdk/hostapd-init.sh \


### PR DESCRIPTION
Provide config templates for open networks and install them.
This is a follow-up to 7a5bb8 ("Hostapd init: add support for open WiFi
networks (#424)")

Signed-off-by: Maciej Kwiecień <mkwiecien@plume.com>