### PR TITLE
Dnsmasq can’t up automatically: Include SRC_URI

### DIFF
--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -16,6 +16,7 @@ SRC_URI_append_dunfell = "file://0001-Work-around-for-brlan0-issue.patch;apply=n
 SRC_URI += "file://posix-gwprovapp.patch;apply=no"
 #This patch will add dummy swctl api which is originally given by brcm for XB3.
 SRC_URI += "file://0002-fix-swctl-missing-api.patch;apply=no"
+SRC_URI += "file://start_dnsmasq_service.patch;apply=no"
 SRC_URI += "file://dhcp_script.sh"
 
 LDFLAGS_append = " \


### PR DESCRIPTION
REFPLTB-1676: Dnsmasq can’t up automatically
Reason for change: Include the SRC_URI for the service file included
Test procedure: Build the utopia component for patch apply
Risks: Low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>