### PR TITLE
Enable WAN_FAILOVER_SUPPORTED in Utopia

### DIFF
--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -25,6 +25,7 @@ LDFLAGS_append = " \
 
 CFLAGS_append = " -Wno-format-extra-args -Wno-error "
 CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' -D_WAN_MANAGER_ENABLED_', '', d)}"
+CFLAGS_append = " -DWAN_FAILOVER_SUPPORTED "
 
 # we need to patch to code for Turris
 do_turris_patches() {


### PR DESCRIPTION
    To fix build error:
    | Utopia/source/firewall/firewall_ext.c:57:14: error: 'EXTENDER_MODE' undeclared (first use in this function)
    |    57 |       if ( ( EXTENDER_MODE == Get_Device_Mode() ) )
    |       |              ^~~~~~~~~~~~~
    | Utopia/source/firewall/firewall_ext.c:57:14: note: each undeclared identifier is reported only once for each function it appears in
    | Utopia/source/firewall/firewall_ext.c:57:31: error: implicit declaration of function 'Get_Device_Mode' [-Werror=implicit-function-declaration]
    |    57 |       if ( ( EXTENDER_MODE == Get_Device_Mode() ) )
    |       |                               ^~~~~~~~~~~~~~~