### PR TITLE
RDKB-40485: Enable WanFailOverSupport flag.

### DIFF
--- a/conf/distro/include/rdk-turris.inc
+++ b/conf/distro/include/rdk-turris.inc
@@ -20,3 +20,6 @@ DISTRO_FEATURES_append = " rdkb_wan_manager"
 
 # RDKB-40900: RDKB support extender/nonrouter profile
 DISTRO_FEATURES_append = " rdkb_extender"
+
+# RDKB-40485: Firewall changes for EXT device. device mode support
+DISTRO_FEATURES_append = " WanFailOverSupportEnable"


### PR DESCRIPTION
Without this flag Utopia build will fail on
implicit declaration of function 'Get_Device_Mode'
These declarations are added under WAN_FAILOVER_SUPPORTED