### PR TITLE
Disable rdkb_extender and WAN_FAILOVER_SUPPORTED in BCI builds

### DIFF
--- a/conf/machine/turris-bci.conf
+++ b/conf/machine/turris-bci.conf
@@ -10,3 +10,5 @@ require turris.conf
 
 DISTRO_FEATURES_append = " bci"
 DISTRO_FEATURES_append = " bci_webui_jst"
+
+DISTRO_FEATURES_remove = " rdkb_extender"

--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -25,7 +25,7 @@ LDFLAGS_append = " \
 
 CFLAGS_append = " -Wno-format-extra-args -Wno-error "
 CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' -D_WAN_MANAGER_ENABLED_', '', d)}"
-CFLAGS_append = " -DWAN_FAILOVER_SUPPORTED "
+CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'bci', '', '-DWAN_FAILOVER_SUPPORTED', d)} "
 
 # we need to patch to code for Turris
 do_turris_patches() {


### PR DESCRIPTION
rdkb_extender and WAN_FAILOVER_SUPPORTED causes BCI build errors.
| ../../../../../../../../../rdkb/components/opensource/ccsp/Utopia/source/service_routed/service_routed.c: In function 'gen_zebra_conf':
| ../../../../../../../../../rdkb/components/opensource/ccsp/Utopia/source/service_routed/service_routed.c:857:23: error: 'last_broadcasted_prefix' undeclared (first use in this function)
|   857 |             if(strlen(last_broadcasted_prefix) != 0)
|       |                       ^~~~~~~~~~~~~~~~~~~~~~~