### PR TITLE
REFPLTB-1790: TurrisFwUpgrade.sh is not working for old turris model

### DIFF
--- a/recipes-common/turris-flash/files/TurrisFwUpgrade.sh
+++ b/recipes-common/turris-flash/files/TurrisFwUpgrade.sh
@@ -32,7 +32,7 @@ elif [ $ActiveRootPartition == "/dev/mmcblk0p5" ]; then
 else ##if $ActiveRootPartition is "/dev/mmcblk0p7"
   TargetRootPartition="/dev/mmcblk0p5"
   BootPartition="/dev/mmcblk0p3"
-  NewTurrisMode=0
+  NewTurrisModel=0
 fi
 echo "ActiveRootPartition: $ActiveRootPartition"
 echo "TargetRootPartition: $TargetRootPartition"


### PR DESCRIPTION
Reason for change: Correcting the typo
Test procedure: FW upgrade with TurrisFwUpgrade.sh script
Risks: None

Signed-off-by: Manigandan Gopalakrishnan <manigandan.gopalakrishnan@ltts.com>