### PR TITLE
Fix double application of ccsp-p-and-m patch

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
+++ b/recipes-ccsp/ccsp/ccsp-p-and-m.bbappend
@@ -21,7 +21,7 @@ CFLAGS_remove = "-Werror"
 
 EXTRA_OECONF_append  = " --with-ccsp-arch=arm"
 
-SRC_URI += "file://resolve_error_with_Get_Device_Mode_API.patch"
+SRC_URI += "file://resolve_error_with_Get_Device_Mode_API.patch;apply=no"
 do_turris_patches() {
     cd ${S}
     if [ ! -e turris_patch_applied ]; then


### PR DESCRIPTION
In nosrc builds, the SRC_URI with patch would be applied as well as the do_turris_patches
resulting in double application.

Specifying apply=no in SRC_URI with patch to fix this.