### PR TITLE
Not able to access WebUI in Turris GW

### DIFF
--- a/recipes-extended/lighttpd/lighttpd_%.bbappend
+++ b/recipes-extended/lighttpd/lighttpd_%.bbappend
@@ -14,6 +14,9 @@ do_install_append() {
     else       
        install -m 0644 ${WORKDIR}/lighttpd_php.conf.broadband ${D}${sysconfdir}/lighttpd.conf
     fi
+
+    sed -i '/mod_redirect/a \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \"mod_openssl\",' ${D}/${sysconfdir}/lighttpd.conf
+    echo "include_shell \"sh /etc/webgui_config.sh\"" >> ${D}/${sysconfdir}/lighttpd.conf
 }
 
 FILES_${PN}_append_morty = " /usr/lib/mod_fastcgi.so"


### PR DESCRIPTION
REFPLTB-1803: Not able to access WebUI in Turris GW

Reason for change: Additional port configuration are done through webgui_config.sh
Test procedure: Found that webgui_config.sh present in image directory
Risks: Low

Signed-off-by: KaviyaKumaresan <Kaviya.Kumaresan@ltts.com>