### PR TITLE
Add removal of CVE-2021-3905.patch in openvswitch

### DIFF
--- a/recipes-networking/openvswitch/openvswitch_git.bbappend
+++ b/recipes-networking/openvswitch/openvswitch_git.bbappend
@@ -10,8 +10,11 @@ DEPENDS_remove_turris5.x += "linux-marvell kernel-devsrc"
 EXTRA_OECONF_remove_turris5.x += "--with-linux=${STAGING_KERNEL_BUILDDIR} --with-linux-source=${STAGING_KERNEL_DIR} KARCH=${TARGET_ARCH} "
 
 # Bad idea, once meta-vitualization is corrected, then won't need this
-SRC_URI_remove_turris5.x += " file://python-switch-remaining-scripts-to-use-python3.patch file://systemd-update-tool-paths.patch file://systemd-create-runtime-dirs.patch"
-SRC_URI_remove_turris5.x += " git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.13 "
+SRC_URI_remove_turris5.x = "file://python-switch-remaining-scripts-to-use-python3.patch"
+SRC_URI_remove_turris5.x = "file://systemd-update-tool-paths.patch"
+SRC_URI_remove_turris5.x = "file://systemd-create-runtime-dirs.patch"
+SRC_URI_remove_turris5.x = "file://CVE-2021-3905.patch"
+SRC_URI_remove_turris5.x = "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.13 "
 SRC_URI_append_turris5.x += "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.17"
 SRCREV_turris5.x = "${AUTOREV}"
 


### PR DESCRIPTION
It is not applicable to the openvswitch branch-2.17 for Turris.