### PR TITLE
REFPLTB-1671: Unify flashing outcome - part 3

### DIFF
--- a/recipes-common/turris-flash/files/TurrisFwUpgrade.sh
+++ b/recipes-common/turris-flash/files/TurrisFwUpgrade.sh
@@ -18,28 +18,30 @@ ls /tmp/zImage* >/dev/null
 check "No new image present in /tmp directory"
 
 BootPartition="/dev/mmcblk0p1"
-NewTurrisModel=1
+PrimaryPartition="/dev/mmcblk0p2"
+SecondaryPartition="/dev/mmcblk0p3"
+PrimaryPartitionLabel="primary"
+SecondaryPartitionLabel="secondary"
 
 ActiveRootPartition=`mount | grep "/" -w | cut -d' ' -f1`
-if [ $ActiveRootPartition == "/dev/mmcblk0p2" ]; then
-  TargetRootPartition="/dev/mmcblk0p3"
-elif [ $ActiveRootPartition == "/dev/mmcblk0p3" ]; then
-  TargetRootPartition="/dev/mmcblk0p2"
-elif [ $ActiveRootPartition == "/dev/mmcblk0p5" ]; then
-  TargetRootPartition="/dev/mmcblk0p7"
-  BootPartition="/dev/mmcblk0p3"
-  NewTurrisModel=0
-else ##if $ActiveRootPartition is "/dev/mmcblk0p7"
-  TargetRootPartition="/dev/mmcblk0p5"
-  BootPartition="/dev/mmcblk0p3"
-  NewTurrisModel=0
+if [ $ActiveRootPartition == $PrimaryPartition ]; then
+  TargetRootPartition=$SecondaryPartition
+  TargetRootPartitionLabel=$SecondaryPartitionLabel
+elif [ $ActiveRootPartition == $SecondaryPartition ]; then
+  TargetRootPartition=$PrimaryPartition
+  TargetRootPartitionLabel=$PrimaryPartitionLabel
+else
+  echo "ActiveRootPartition: $ActiveRootPartition."
+  echo "Usupported partition layout. Upgrade your Turris box via USB first."
+  exit 1
 fi
+
 echo "ActiveRootPartition: $ActiveRootPartition"
 echo "TargetRootPartition: $TargetRootPartition"
 echo "BootPartition: $BootPartition"
 
 umount /mnt 2>/dev/null
-echo y | mkfs.ext2 $TargetRootPartition
+echo y | mkfs.ext4 $TargetRootPartition -L $TargetRootPartitionLabel
 check "Error in formatting $TargetRootPartition"
 
 mount $TargetRootPartition /mnt
@@ -58,27 +60,22 @@ check "Error in mounting $BootPartition"
 mv /mnt/zImage /zImage_old
 cp /tmp/zImage* /mnt/zImage
 if [ $? != 0 ]; then
-echo "Error in copying zImage. Falling back."
-mv /zImage_old /mnt/zImage
-exit 1
+  echo "Error in copying zImage. Falling back."
+  mv /zImage_old /mnt/zImage
+  exit 1
 fi
 
 mv /mnt/armada-385-turris-omnia.dtb /mnt/armada-385-turris-omnia.dtb_old
 cp /tmp/armada-385-turris-omnia.dtb /mnt/
 if [ $? != 0 ]; then
-echo "Error in copying dtb file. Falling back."
-mv /mnt/armada-385-turris-omnia.dtb_old /mnt/armada-385-turris-omnia.dtb
-exit 1
+  echo "Error in copying dtb file. Falling back."
+  mv /mnt/armada-385-turris-omnia.dtb_old /mnt/armada-385-turris-omnia.dtb
+  exit 1
 fi
 
-if [ $NewTurrisModel -eq 1 ]; then
-  echo "Updating boot script for newer model of turris omnia"
-  if [ $TargetRootPartition == "/dev/mmcblk0p2" ]; then
-    cp /boot-main.scr /mnt/boot.scr
-  else
-    cp /boot-alt.scr /mnt/boot.scr
-  fi
+if [ $TargetRootPartition == $PrimaryPartition ]; then
+  cp /boot-main.scr /mnt/boot.scr
 else
-  echo "Updating U-Boot environment variables for older model of turris omnia"
-  fw_setenv yocto_bootargs earlyprintk console=ttyS0,115200 root=$TargetRootPartition rootfstype=ext2 rw rootwait
+  cp /boot-alt.scr /mnt/boot.scr
 fi
+umount /mnt

--- a/recipes-common/turris-flash/files/nvram.mount
+++ b/recipes-common/turris-flash/files/nvram.mount
@@ -1,0 +1,12 @@
+[Unit]
+Before=local-fs.target
+
+[Mount]
+Where=/nvram
+What=/dev/disk/by-label/nvram1
+
+[Service]
+TimeoutSec=5
+
+[Install]
+WantedBy=local-fs.target

--- a/recipes-common/turris-flash/turris-flash.bb
+++ b/recipes-common/turris-flash/turris-flash.bb
@@ -5,14 +5,23 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 RDEPENDS_${PN} = "bash"
 
+inherit systemd
+
 SRC_URI = "file://TurrisFwUpgrade.sh"
+SRC_URI += "file://nvram.mount"
 
 do_compile[noexec] = "1"
 do_configure[noexec] = "1"
 
 do_install() {
     install -d ${D}${base_libdir}/rdk
-    install -m 0755 ${WORKDIR}/TurrisFwUpgrade.sh ${D}${base_libdir}/rdk
+    install -m 0755 ${WORKDIR}/TurrisFwUpgrade.sh ${D}${base_libdir}/rdk/
+
+    install -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${WORKDIR}/nvram.mount ${D}${systemd_unitdir}/system/
 }
 
+SYSTEMD_SERVICE_${PN} = "nvram.mount"
+
 FILES_${PN} = "${base_libdir}/rdk/TurrisFwUpgrade.sh"
+FILES_${PN} += "${systemd_unitdir}/system/nvram.mount"

--- a/recipes-connectivity/hostapd/files/hostapd.service
+++ b/recipes-connectivity/hostapd/files/hostapd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Hostapd IEEE 802.11n AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator
-After=CcspPandMSsp.service
+After=CcspPandMSsp.service nvram.mount
+Wants=nvram.mount
 StartLimitIntervalSec=120
 
 [Service]


### PR DESCRIPTION
- Use designated systemd mount unit for mounting /nvram based on the label
- As a fallback keep the old /nvram mounting code in hostapd-init.sh and do not 'Require=' that the service is started when /nvram is already mounted, but only set the dependency to 'Wants='
- Remove the legacy NewTurrisModel=0 variant from TurrisFwUpgrade.sh
- When flashing from script use labels and ext4 for rootfs, same as in USB flash

Signed-off-by: Piotr Nakraszewicz <piotr.nakraszewicz@consult.red>
Signed-off-by: Piotr Nakraszewicz <pnakraszewicz@plume.com>