### PR TITLE
REFPLTB-1879: Fix rootfs generation

### DIFF
--- a/recipes-core/images/rdk-generic-broadband-image.bbappend
+++ b/recipes-core/images/rdk-generic-broadband-image.bbappend
@@ -48,9 +48,12 @@ BUILDHISTORY_COMMIT = "1"
 require image-exclude-files.inc
 
 remove_unused_file() {
-   for i in ${REMOVED_FILE_LIST} ; do rm -rf ${IMAGE_ROOTFS}/$i ; done
-   #Creating /opt/secure folder for ssh service
-   mkdir ${IMAGE_ROOTFS}/opt/secure
+    for i in ${REMOVED_FILE_LIST} ; do rm -rf ${IMAGE_ROOTFS}/$i ; done
 }
 
-ROOTFS_POSTPROCESS_COMMAND_append = "remove_unused_file; "
+ssh_workaround_opt_secure() {
+    #Creating /opt/secure folder for ssh service
+    install -d ${IMAGE_ROOTFS}/opt/secure
+}
+
+ROOTFS_POSTPROCESS_COMMAND_append = " remove_unused_file; ssh_workaround_opt_secure; "

--- a/recipes-core/images/rdk-generic-broadband-tdk-image.bbappend
+++ b/recipes-core/images/rdk-generic-broadband-tdk-image.bbappend
@@ -46,9 +46,12 @@ BUILDHISTORY_COMMIT = "1"
 require image-exclude-files.inc
 
 remove_unused_file() {
-   for i in ${REMOVED_FILE_LIST} ; do rm -rf ${IMAGE_ROOTFS}/$i ; done
-   #Creating /opt/secure folder for ssh service
-   mkdir ${IMAGE_ROOTFS}/opt/secure
+    for i in ${REMOVED_FILE_LIST} ; do rm -rf ${IMAGE_ROOTFS}/$i ; done
 }
 
-ROOTFS_POSTPROCESS_COMMAND_append = "remove_unused_file; "
+ssh_workaround_opt_secure() {
+    #Creating /opt/secure folder for ssh service
+    install -d ${IMAGE_ROOTFS}/opt/secure
+}
+
+ROOTFS_POSTPROCESS_COMMAND_append = " remove_unused_file; ssh_workaround_opt_secure; "

--- a/recipes-core/images/rdk-generic-extender-image.bb
+++ b/recipes-core/images/rdk-generic-extender-image.bb
@@ -33,9 +33,12 @@ SYSTEMD_TOOLS_remove_libc-musl = "systemd-bootchart"
 do_rootfs[nostamp] = "1"
 
 remove_unused_file() {
- rm -rf ${IMAGE_ROOTFS}/usr/lib/python* ;
- #Creating /opt/secure folder for ssh service
- mkdir -p ${IMAGE_ROOTFS}/opt/secure
+    rm -rf ${IMAGE_ROOTFS}/usr/lib/python* ;
 }
 
-ROOTFS_POSTPROCESS_COMMAND_append = "remove_unused_file; "
+ssh_workaround_opt_secure() {
+    #Creating /opt/secure folder for ssh service
+    install -d ${IMAGE_ROOTFS}/opt/secure
+}
+
+ROOTFS_POSTPROCESS_COMMAND_append = " remove_unused_file; ssh_workaround_opt_secure; "


### PR DESCRIPTION
Use install instead of mkdir, so that the directory is created even if preceding directories (/opt in this case) don't exist.

Extract out the workaround so that the function named "remove_unused_file" does only that, and doesn't create any directories.

Fix spacing.

Signed-off-by: Piotr Nakraszewicz <piotr.nakraszewicz@consult.red>