### PR TITLE
RDKB-44755: RDKB - Use RBUS from RDKCentral github

### DIFF
--- a/conf/distro/include/rdk-turris.inc
+++ b/conf/distro/include/rdk-turris.inc
@@ -14,6 +14,8 @@ DISTRO_FEATURES_append = " dslite"
 # REFPLTV-1137: DLNA support for xupnp
 DISTRO_FEATURES_append = " dlna"
 
+DISTRO_FEATURES_append = " webconfig_bin"
+
 DISTRO_FEATURES_append = " meshwifi"
 DISTRO_FEATURES_append = " ipv6"
 DISTRO_FEATURES_append = " rdkb_cellular_manager"


### PR DESCRIPTION
Reason for change: Using Federated Rbus from RDKCentral github for RDKB instead of seperate Gerrit links for rbus,rbus-core,rtmessage, Test Procedure: Turris builds are OK
Risks: None

Signed-off-by: Simon Chung <simon.chung@rdkcentral.com>