### PR TITLE
REFPLTB-1913: Add Update-bhaul-credential.patch for turris extender b…

### DIFF
--- a/recipes-connectivity/opensync/files/0001-Update-bhaul-credential.patch
+++ b/recipes-connectivity/opensync/files/0001-Update-bhaul-credential.patch
@@ -1,0 +1,27 @@
+From 8aff7681b197d1272e79ab00defbd07b94ea9d24 Mon Sep 17 00:00:00 2001
+From: manigandanj <manigandan.gopalakrishnan@ltts.com>
+Date: Mon, 12 Dec 2022 17:16:49 +0000
+Subject: [PATCH] Update bhaul credential
+
+Signed-off-by: manigandanj <manigandan.gopalakrishnan@ltts.com>
+---
+ build/provider.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/build/provider.mk b/build/provider.mk
+index aa06ce9..819bd0b 100644
+--- a/build/provider.mk
++++ b/build/provider.mk
+@@ -11,7 +11,7 @@ IMAGE_PROFILE_SUFFIX := "$(IMAGE_DEPLOYMENT_PROFILE)"
+ # pre-populated WiFi related OVSDB entries needed for extender devices.
+ # (See also: core/ovsdb/20_kconfig.radio.json.sh)
+
+-export BACKHAUL_SSID := "dummy_onboard_ssid"
+-export BACKHAUL_PASS := "dummy_onboard_psk"
++export BACKHAUL_SSID := "UPDATE_SSID"
++export BACKHAUL_PASS := "UPDATE_PASSWORD"
+
+ endif
+--
+2.17.1
+

--- a/recipes-connectivity/opensync/opensync_git.bbappend
+++ b/recipes-connectivity/opensync/opensync_git.bbappend
@@ -1,2 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 OPENSYNC_VENDOR_URI += "file://turris-bci-target.patch;patchdir=${WORKDIR}/git/vendor/turris"
+OPENSYNC_SERVICE_PROVIDER_URI += " ${@bb.utils.contains('DISTRO_FEATURES', 'extender', 'file://0001-Update-bhaul-credential.patch;patchdir=${WORKDIR}/git/service-provider/local', '', d)} "


### PR DESCRIPTION
…uild

Reason for change: In order to provide cleaner build instruction
Test procedure: Found that updated SSID and Password is getting reflected in provider.mk
isks: None

Signed-off-by: Manigandan Gopalakrishnan <manigandan.gopalakrishnan@ltts.com>