### PR TITLE
hostapd-init: set mac address new interfaces

### DIFF
--- a/recipes-connectivity/hostapd/files/hostapd-init.sh
+++ b/recipes-connectivity/hostapd/files/hostapd-init.sh
@@ -215,6 +215,11 @@ ifconfig wifi7 mtu 1600
 iw dev ${WLAN24G} interface add wifi8 type __ap
 iw dev ${WLAN5G} interface add wifi9 type __ap
 
+#update mac from hostapd config
+for i in $(seq 9); do
+        ifconfig wifi$i hw ether $(cat /nvram/hostapd${i}.conf |grep bssid | cut -d = -f 2)
+done
+
 #Create empty acl list for hostapd
 touch /tmp/hostapd-acl0
 touch /tmp/hostapd-acl1


### PR DESCRIPTION
Set mac address on interfaces from hostapd config.
During startup other services set newly created interfaces up.
Newly created interfaces may have not unique mac address and setting them up may fail
