### PR TITLE
Add RbusBuildFlagEnable DISTRO_FEATURES

### DIFF
--- a/conf/distro/include/rdk-turris.inc
+++ b/conf/distro/include/rdk-turris.inc
@@ -30,3 +30,6 @@ DISTRO_FEATURES_append = " core-net-lib"
 
 #Kernel upgrade
 DISTRO_FEATURES_append = " kernel5.x"
+
+# Fix RDK Cellular Manager build errors
+DISTRO_FEATURES_append = " RbusBuildFlagEnable"


### PR DESCRIPTION
It is needed to fix RDK Cellular Manager build errors | RdkCellularManager/source/CellularManager/cellularmgr_cellular_apis.c:793:11: error: 'gRBUSSubListSt' undeclared (first use in this function)
|   793 |     if( ( gRBUSSubListSt.stRadioSignal.RSSISubFlag ) ||
|       |           ^~~~~~~~~~~~~~

after RdkCellularManager/+/82287 is merged.