### PR TITLE
RDKB-48428: Trivial changes for Piecemeal merge

### DIFF
--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -5,6 +5,7 @@ DEPENDS_append = " kernel-autoconf utopia-headers libsyswrapper telemetry"
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 EXTRA_OECONF_append  = " --with-ccsp-arch=arm"
+EXTRA_OECONF_remove  = "--with-ccsp-platform=bcm"
 
 SRC_URI_append = " \
     file://0001-fix-lan-handler-for-turris.patch;apply=no \


### PR DESCRIPTION
Add override to fix build after kirkstone changes in meta-rdk-broadband/+/84322 | Utopia/source/service_multinet/service_multinet_main.c:313: error: undefined reference to 'addIpcVlan' | Utopia/source/service_multinet/service_multinet_main.c:321: error: undefined reference to 'addRadiusVlan' | Utopia/source/service_multinet/service_multinet_main.c:329: error: undefined reference to 'createMeshVlan' | Utopia/source/service_multinet/service_multinet_main.c:337: error: undefined reference to 'addMeshBhaulVlan' | Utopia/source/service_multinet/service_multinet_main.c:305: error: undefined reference to 'setMulticastMac'