### PR TITLE
REFPLTB-2483 : Backhaul is not getting associated without the opensync dependancy on hostapd.service

### DIFF
--- a/recipes-connectivity/hostapd/files/hostapd.service
+++ b/recipes-connectivity/hostapd/files/hostapd.service
@@ -2,6 +2,7 @@
 Description=Hostapd IEEE 802.11n AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator
 After=CcspPandMSsp.service
 StartLimitIntervalSec=120
+After=opensync.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Reason for change : Backhaul is not getting associated from turris extender to superpod
Test Procedure : Backhaul wifi is getting associated with superpod
Risks : Low