### PR TITLE
REFPLTB-2531 : Latest turris build is breaking after improting of comcast change(87358)

### DIFF
--- a/conf/machine/turris-extender.conf
+++ b/conf/machine/turris-extender.conf
@@ -20,6 +20,7 @@ TCLIBC = "musl"
 
 UBOOT_MACHINE = "turris_omnia_defconfig"
 MACHINEOVERRIDES .= ":extender:turris"
+MACHINEOVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'kernel5.x', ':turris5.x', '', d)}"
 
 PREFERRED_PROVIDER_u-boot ??= "u-boot-turris"
 PREFERRED_PROVIDER_u-boot-fw-utils ??= "u-boot-fw-utils-turris"

--- a/recipes-networking/openvswitch/openvswitch_git.bbappend
+++ b/recipes-networking/openvswitch/openvswitch_git.bbappend
@@ -14,6 +14,7 @@ SRC_URI_remove_turris5.x = "file://python-switch-remaining-scripts-to-use-python
 SRC_URI_remove_turris5.x = "file://systemd-update-tool-paths.patch"
 SRC_URI_remove_turris5.x = "file://systemd-create-runtime-dirs.patch"
 SRC_URI_remove_turris5.x = "file://CVE-2021-3905.patch"
+SRC_URI_remove_turris5.x = "file://CVE-2021-36980_fix.patch"
 SRC_URI_remove_turris5.x = "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.13 "
 SRC_URI_append_turris5.x += "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.17"
 SRCREV_turris5.x = "${AUTOREV}"


### PR DESCRIPTION

Reason for change : Below errors are observed,
ERROR: openvswitch-2.17+AUTOINC+e206df08d2-r0 do_patch: Command Error: 'quilt --quiltrc Applying patch CVE-2021-36980_fix.patch
patching file lib/ofp-actions.c
Hunk #1 FAILED at 4346.
Hunk #2 FAILED at 4373.
2 out of 2 hunks FAILED -- rejects in file lib/ofp-actions.c patching file tests/automake.mk
Hunk #1 FAILED at 132.
1 out of 1 hunk FAILED -- rejects in file tests/automake.mk patching file tests/fuzz-regression-list.at
Hunk #1 FAILED at 21.
1 out of 1 hunk FAILED -- rejects in file tests/fuzz-regression-list.at The next patch would empty out the file tests/fuzz-regression/ofp_print_fuzzer-6540965472632832, which is already empty!  Applying it anyway.
patching file tests/fuzz-regression/ofp_print_fuzzer-6540965472632832 Patch CVE-2021-36980_fix.patch does not apply (enforce with -f) Test Procedure: bitbake openvswitch
Risks: Low