### PR TITLE
REFPLTB-2531 : Fix openvswtich in turris builds

### DIFF
--- a/conf/machine/turris-extender.conf
+++ b/conf/machine/turris-extender.conf
@@ -20,6 +20,7 @@ TCLIBC = "musl"
 
 UBOOT_MACHINE = "turris_omnia_defconfig"
 MACHINEOVERRIDES .= ":extender:turris"
+MACHINEOVERRIDES .= "${@bb.utils.contains('DISTRO_FEATURES', 'kernel5.x', ':turris5.x', '', d)}"
 
 PREFERRED_PROVIDER_u-boot ??= "u-boot-turris"
 PREFERRED_PROVIDER_u-boot-fw-utils ??= "u-boot-fw-utils-turris"

--- a/recipes-networking/openvswitch/openvswitch_git.bbappend
+++ b/recipes-networking/openvswitch/openvswitch_git.bbappend
@@ -14,6 +14,7 @@ SRC_URI_remove_turris5.x = "file://python-switch-remaining-scripts-to-use-python
 SRC_URI_remove_turris5.x = "file://systemd-update-tool-paths.patch"
 SRC_URI_remove_turris5.x = "file://systemd-create-runtime-dirs.patch"
 SRC_URI_remove_turris5.x = "file://CVE-2021-3905.patch"
+SRC_URI_remove_turris5.x = "file://CVE-2021-36980_fix.patch"
 SRC_URI_remove_turris5.x = "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.13 "
 SRC_URI_append_turris5.x += "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.17"
 SRCREV_turris5.x = "${AUTOREV}"


### PR DESCRIPTION
Build errors are due to meta-rdk-video/+/85401

Remove openvswitch CVE-2021-36980_fix.patch since it is already in 2.17 Add turris5.x MACHINEOVERRIDES to Extender to fix openvswitch build.