### PR TITLE
RDKB-48391 Enable WanFailOverSupportEnable DISTRO_FEATURES for broadband

### DIFF
--- a/conf/distro/include/rdk-turris.inc
+++ b/conf/distro/include/rdk-turris.inc
@@ -33,3 +33,6 @@ DISTRO_FEATURES_append = " kernel5.x"
 
 # Fix RDK Cellular Manager build errors
 DISTRO_FEATURES_append = " RbusBuildFlagEnable"
+
+# Fix MeshAgent build errors
+DISTRO_FEATURES_append = " WanFailOverSupportEnable"


### PR DESCRIPTION
DISTRO_FEATURES WanFailOverSupportEnable is required to fix MeshAgent issues introduced by MeshAgent/+/87476