### PR TITLE
REFPLTB-2547,REFPLTB-2548 : Observed initial Parodus crash and WebUI …

### DIFF
--- a/recipes-ccsp/util/utopia/system_defaults
+++ b/recipes-ccsp/util/utopia/system_defaults
@@ -538,7 +538,8 @@ $mgmt_https_enable=0
 $mgmt_wifi_access=1
 
 $mgmt_wan_access=1
-$mgmt_wan_httpaccess=1
+$mgmt_wan_httpaccess_ert=1
+$mgmt_wan_httpaccess=0
 $mgmt_wan_httpsaccess=0
 $mgmt_wan_sshaccess=1
 $mgmt_wan_telnetaccess=0

--- a/recipes-support/parodus/files/parodus_start.sh
+++ b/recipes-support/parodus/files/parodus_start.sh
@@ -23,7 +23,7 @@ GET="dmcli eRT getv"
 SET=""
 
 echo "Fetching PAM Health status "
-
+sleep 10
 while [ 1 ]
 do
    pamState=`$GET com.cisco.spvtg.ccsp.pam.Health | grep value| tr -s ' ' |cut -f5 -d" "`


### PR DESCRIPTION
…is not accessible through erouter0:8080 (#541)

Reason for change : Added required changes to avoid these issues Test Procedure: Initial parodus crash is not observed and able to access WebUI via erouter0IP:8080
Risks: Low