### PR TITLE
Fix BCI utopia build after WanFailOverSupportEnable DISTRO_FEATURES has been enabled

### DIFF
--- a/recipes-ccsp/util/utopia.bbappend
+++ b/recipes-ccsp/util/utopia.bbappend
@@ -27,7 +27,7 @@ LDFLAGS_append = " \
 
 CFLAGS_append = " -Wno-format-extra-args -Wno-error "
 CFLAGS_append += "${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', ' -D_WAN_MANAGER_ENABLED_', '', d)}"
-CFLAGS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'bci', '', '-DWAN_FAILOVER_SUPPORTED', d)} "
+CFLAGS_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'bci', '-DWAN_FAILOVER_SUPPORTED', '', d)}"
 
 # we need to patch to code for Turris
 do_turris_patches() {


### PR DESCRIPTION
The WAN_FAILOVER_SUPPORTED CFLAGS needs to be removed explicitly for bci builds,

Build error:
| Utopia/source/service_routed/service_routed.c:1059:23: error: 'last_broadcasted_prefix' undeclared (first use in this function)
|  1059 |             if(strlen(last_broadcasted_prefix) != 0)
|       |                       ^~~~~~~~~~~~~~~~~~~~~~~
| Utopia/source/service_routed/service_routed.c:1059:23: note: each undeclared identifier is reported only once for each function it appears in
| Makefile:476: recipe for target 'service_routed-service_routed.o' failed
| make[3]: *** [service_routed-service_routed.o] Error 1