### PR TITLE
REFPLTB-2629 : Turris GW: NAT is not working with q2 build

### DIFF
--- a/recipes-ccsp/ccsp/files/udhcpc_check.sh
+++ b/recipes-ccsp/ccsp/files/udhcpc_check.sh
@@ -1,8 +1,11 @@
 #!bin/sh
 #### Added workaround fix for getting erouter0 IP
-sleep 60
+sleep 30
 EROUTER_IP=`ifconfig erouter0 | grep "inet addr" | xargs | cut -d ':' -f2 | cut -d ' ' -f1`
 echo "erouter0 ip is $EROUTER_IP"
 if [ "$EROUTER_IP" = "" ] ; then  
      udhcpc -i erouter0
 fi
+EROUTER_IP=`ifconfig erouter0 | grep "inet addr" | xargs | cut -d ':' -f2 | cut -d ' ' -f1`
+sysevent set current_wan_ipaddr $EROUTER_IP
+


### PR DESCRIPTION
Reason for change : Connected clients are not getting Internet while connected with Turris GW
Test Procedure: Lan clients and wifi clients are getting Internet
Risks: Low