### PR TITLE
Refresh ccsp-wifi-agent patches

### DIFF
--- a/recipes-ccsp/ccsp/ccsp-wifi-agent/handle_mesh-rename-opensync.patch
+++ b/recipes-ccsp/ccsp/ccsp-wifi-agent/handle_mesh-rename-opensync.patch
@@ -1,37 +1,41 @@
-From 820c4cb8acb58ad2a32bbfbc369524bef4eb6e75 Mon Sep 17 00:00:00 2001
-From: Jenkins Slave <jenkins@code.rdkcentral.com>
-Date: Fri, 11 Aug 2023 12:45:27 +0100
+From 4923ae61be42bf762bfe233192f3fc5c466201c9 Mon Sep 17 00:00:00 2001
+From: Simon Chung <simon.chung@rdkcentral.com>
+Date: Mon, 14 Aug 2023 16:01:06 +0100
 Subject: [PATCH] handle_mesh-rename-opensync
 
-Change-Id: I58040961157424a4e1783cdfad6ad8a19a63479e
+Change-Id: I26a54ce3ac644d37984a3a96f8b0418e065bb049
 ---
- scripts/handle_mesh | 12 ++++++++++--
- 1 file changed, 10 insertions(+), 2 deletions(-)
+ scripts/handle_mesh | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/scripts/handle_mesh b/scripts/handle_mesh
-index ddb600e..64c4e54 100644
+index ddb600e2..95dd6da6 100644
 --- a/scripts/handle_mesh
 +++ b/scripts/handle_mesh
-@@ -51,11 +51,18 @@ is_opensync_name()
+@@ -51,6 +51,12 @@ is_opensync_name()
      done
      return 1
  }
++
 +is_opensync_service()
 +{
 +    systemctl list-unit-files opensync.service | grep -q opensync.service
 +}
++
  if [ $# -eq 0 ]; then
   echo "No arguments passed"
   exit 0
- else
-  platform_checks
-+ if is_opensync_service; then
-+        systemctl $1 opensync.service
-+ else
-  if [ "$OPENSYNC_44_ENABLE" == "true" ]
-  then
+@@ -61,6 +67,9 @@ else
      echo "OPENSYNC_44_ENABLE is true"
-@@ -70,9 +77,10 @@ else
+     OPENSYNC_SCRIPTS_PATH=/usr/opensync_44/scripts
+  fi
++ if is_opensync_service; then
++    systemctl $1 opensync.service
++ else
+  if [ -f /etc/WFO_enabled ] || [ "$OPENSYNC_ENABLE" == "true" ] && [ -d "/sys/module/openvswitch" ];then
+     if [ -z "$(pidof ovsdb-server)" ]
+     then
+@@ -70,9 +79,10 @@ else
          $OPENSYNC_SCRIPTS_PATH/managers.init $1
      else
          echo "Opensync will be effective only after reboot"
@@ -41,9 +45,9 @@ index ddb600e..64c4e54 100644
   else
 -  /usr/plume/scripts/managers.init $1
 +  /usr/opensync/scripts/managers.init $1
-+ fi
++  fi
   fi
  fi
 -- 
-2.37.3
+2.37.2
 


### PR DESCRIPTION
Patch updates are required after changes to ccsp-wifi-agent handle_mesh-rename-opensync.patch