### PR TITLE
RDKB-51565,RDKB-50795: [HAL] Cellular Hal Implementation

### DIFF
--- a/conf/distro/include/rdk-turris.inc
+++ b/conf/distro/include/rdk-turris.inc
@@ -16,9 +16,13 @@ DISTRO_FEATURES_append = " dlna"
 
 DISTRO_FEATURES_append = " webconfig_bin"
 
+# RDKB-51565,RDKB-50795: [HAL] Cellular Hal Implementation
+DISTRO_FEATURES_append = " rdkb_cellular_manager"
+DISTRO_FEATURES_append = " cellular_mgr_lite"
+DISTRO_FEATURES_append = " cellular_libqmi_support"
+
 DISTRO_FEATURES_append = " meshwifi"
 DISTRO_FEATURES_append = " ipv6"
-DISTRO_FEATURES_append = " rdkb_cellular_manager"
 DISTRO_FEATURES_append = " rdkb_wan_manager"
 DISTRO_FEATURES_append = " rdkb_inter_device_manager"
 


### PR DESCRIPTION
Enable DISTRO_FEATURES cellular_mgr_lite and cellular_libqmi_support as a result of RdkCellularManager/+/94606 to fix build issues.